### PR TITLE
fix(ci): clarify tag pattern matching in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'  # For pre-release versions
 
 permissions:
   contents: write # Required for creating releases


### PR DESCRIPTION
- Split tag pattern into explicit matches for release and pre-release versions
- Update pattern to ensure v0.0.1 style versions trigger correctly
- Add support for pre-release version tags with hyphen suffix

This fixes issues where the release workflow wasn't triggering on valid version tags.