### PR TITLE
Allow address to be overridden on cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.3
 
 require (
+	github.com/spf13/cobra v1.8.1
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/client-go v0.32.0
@@ -24,6 +25,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,6 +36,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -68,6 +71,9 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/webhook/cmd/main.go
+++ b/pkg/webhook/cmd/main.go
@@ -6,8 +6,9 @@ import (
 	"net"
 	"os"
 
-	"github.com/jjshanks/pod-label-webhook/pkg/webhook"
 	"github.com/spf13/cobra"
+
+	"github.com/jjshanks/pod-label-webhook/pkg/webhook"
 )
 
 var (

--- a/pkg/webhook/cmd/main.go
+++ b/pkg/webhook/cmd/main.go
@@ -1,13 +1,55 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net"
+	"os"
 
 	"github.com/jjshanks/pod-label-webhook/pkg/webhook"
+	"github.com/spf13/cobra"
 )
 
+var (
+	address string
+	rootCmd = &cobra.Command{
+		Use:   "webhook",
+		Short: "Kubernetes admission webhook for pod labeling",
+		Long:  `A webhook server that adds labels to pods using Kubernetes admission webhooks`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Validate address format
+			host, port, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("invalid address format %q: %v", address, err)
+			}
+
+			// Validate port
+			if _, err := net.LookupPort("tcp", port); err != nil {
+				return fmt.Errorf("invalid port %q: %v", port, err)
+			}
+
+			// Validate host
+			if host != "" && host != "0.0.0.0" {
+				if ip := net.ParseIP(host); ip == nil {
+					return fmt.Errorf("invalid IP address: %q", host)
+				}
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return webhook.Run(address)
+		},
+	}
+)
+
+func init() {
+	rootCmd.Flags().StringVar(&address, "address", "0.0.0.0:8443", "The address and port to listen on (e.g., 0.0.0.0:8443)")
+}
+
 func main() {
-	if err := webhook.Run(); err != nil {
-		log.Fatalf("Failed to start webhook: %v", err)
+	if err := rootCmd.Execute(); err != nil {
+		log.Printf("Error: %v", err)
+		os.Exit(1)
 	}
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -190,6 +191,9 @@ func Run(address string) error {
 		WriteTimeout:      10 * time.Second,
 		ReadTimeout:       10 * time.Second,
 		IdleTimeout:       120 * time.Second,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
 	}
 
 	log.Printf("Starting webhook server on %s", address)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -153,7 +153,7 @@ func handleMutate(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func Run() error {
+func Run(address string) error {
 	certPath := "/etc/webhook/certs/tls.crt"
 	keyPath := "/etc/webhook/certs/tls.key"
 
@@ -184,7 +184,7 @@ func Run() error {
 	mux.HandleFunc("/mutate", handleMutate)
 
 	server := &http.Server{
-		Addr:              ":8443",
+		Addr:              address,
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 		WriteTimeout:      10 * time.Second,
@@ -192,6 +192,6 @@ func Run() error {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	log.Printf("Starting webhook server on :8443")
+	log.Printf("Starting webhook server on %s", address)
 	return server.ListenAndServeTLS(certPath, keyPath)
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a CLI option to allow overriding the default address and port for the webhook server, with validation for the address format.

New Features:
- Introduce a CLI option to override the default address and port for the webhook server.

Enhancements:
- Add validation for the address format, including host and port, before starting the webhook server.