### PR TITLE
refactor: simplify makefile and improve local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,9 @@ docker-push: docker-build
 dev-setup:
 	kind create cluster --name $(KIND_CLUSTER_NAME) --config manifests/kind-config.yaml
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
-	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager
-	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-cainjector
-	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-webhook
+	kubectl wait --for=condition=Ready --timeout=300s -n cert-manager deployment/cert-manager
+	kubectl wait --for=condition=Ready --timeout=300s -n cert-manager deployment/cert-manager-cainjector
+	kubectl wait --for=condition=Ready --timeout=300s -n cert-manager deployment/cert-manager-webhook
 
 # Development cleanup
 dev-cleanup:

--- a/Makefile
+++ b/Makefile
@@ -1,132 +1,101 @@
-# Variables
-CLUSTER_NAME := webhook-test
-IMAGE_NAME := pod-label-webhook
-IMAGE_TAG := latest
-KIND_CONFIG := manifests/kind-config.yaml
+# Build variables
+BINARY_NAME=pod-label-webhook
+DOCKER_REPO=ghcr.io/jjshanks
+IMAGE_NAME=$(DOCKER_REPO)/$(BINARY_NAME)
+VERSION?=latest
+
+# Kubernetes related variables
+NAMESPACE=pod-label-system
+KIND_CLUSTER_NAME=add-label-webhook
+
+.PHONY: all build test clean docker-build docker-push dev-setup dev-cleanup deploy undeploy lint lint-yaml lint-all verify
 
 # Default target
-.PHONY: help
+all: build
+
+# Build using goreleaser
+build:
+	goreleaser build --snapshot --clean
+
+# Run all tests
+test:
+	go test -v -race -cover ./...
+
+# Run integration tests
+test-integration:
+	go test -v -tags=integration ./...
+
+# Clean build artifacts
+clean:
+	rm -rf dist/
+	go clean -testcache
+
+# Build docker image using goreleaser
+docker-build:
+	goreleaser build --snapshot --clean
+
+# Push docker image
+docker-push: docker-build
+	docker push $(IMAGE_NAME):$(VERSION)
+
+# Development setup - creates kind cluster with cert-manager
+dev-setup:
+	kind create cluster --name $(KIND_CLUSTER_NAME) --config manifests/kind-config.yaml
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager
+	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-cainjector
+	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-webhook
+
+# Development cleanup
+dev-cleanup:
+	kind delete cluster --name $(KIND_CLUSTER_NAME)
+
+# Deploy to local Kind cluster
+deploy:
+	kubectl create namespace $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	kubectl apply -f manifests/webhook.yaml
+	# Wait for cert-manager to generate the certificate
+	kubectl wait --for=condition=Ready --timeout=60s -n $(NAMESPACE) certificate/pod-label-webhook-cert
+	kubectl apply -f manifests/deployment.yaml
+
+# Build and load image into Kind
+dev-build: docker-build
+	kind load docker-image $(IMAGE_NAME):$(VERSION) --name $(KIND_CLUSTER_NAME)
+
+# Remove from Kubernetes
+undeploy:
+	kubectl delete -f manifests/deployment.yaml -f manifests/webhook.yaml --ignore-not-found
+	kubectl delete namespace $(NAMESPACE) --ignore-not-found
+
+# Run Go linting
+lint:
+	golangci-lint run ./...
+
+# Run YAML linting
+lint-yaml:
+	yamllint .
+
+# Run all linting
+lint-all: lint lint-yaml
+
+# Verify all checks pass (useful for pre-commit)
+verify: lint-all test
+
+# Help target
 help:
 	@echo "Available targets:"
-	@echo "  create-cluster  - Creates a new kind cluster and installs cert-manager"
-	@echo "  delete-cluster  - Deletes the kind cluster"
-	@echo "  build          - Builds the webhook Docker image"
-	@echo "  load           - Loads the webhook image into kind cluster"
-	@echo "  deploy         - Deploys the webhook to the cluster"
-	@echo "  test           - Creates a test pod to verify webhook"
-	@echo "  debug          - Shows status of webhook deployment"
-	@echo "  all            - Builds, creates cluster, loads image, and deploys"
-
-.PHONY: create-cluster
-create-cluster:
-	@echo "Creating kind cluster..."
-	kind create cluster --name $(CLUSTER_NAME) --config $(KIND_CONFIG)
-	@echo "Installing cert-manager..."
-	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
-	@echo "Waiting for cert-manager namespace to be ready..."
-	sleep 15
-	@echo "Waiting for cert-manager pods..."
-	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cert-manager -n cert-manager --timeout=90s
-	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=webhook -n cert-manager --timeout=90s
-	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cainjector -n cert-manager --timeout=90s
-	@echo "Cert-manager installation complete"
-
-.PHONY: delete-cluster
-delete-cluster:
-	@echo "Deleting kind cluster..."
-	kind delete cluster --name $(CLUSTER_NAME)
-
-.PHONY: build
-build:
-	@echo "Building webhook image..."
-	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
-
-.PHONY: load
-load: build
-	@echo "Loading image into kind cluster..."
-	kind load docker-image $(IMAGE_NAME):$(IMAGE_TAG) --name $(CLUSTER_NAME)
-
-.PHONY: deploy
-deploy:
-	@echo "Deploying webhook..."
-	kubectl apply -f manifests/webhook.yaml
-	@echo "Waiting for webhook namespace to be created..."
-	sleep 5
-	@echo "Deploying webhook deployment and service..."
-	kubectl apply -f manifests/deployment.yaml
-	@echo "Waiting for webhook pod to be ready..."
-	kubectl wait --for=condition=ready pod -l app=pod-label-webhook -n pod-label-system --timeout=90s
-	@echo "Waiting for webhook to be fully operational..."
-	sleep 10
-	@echo "Deployment complete"
-
-.PHONY: test
-test:
-	@echo "Creating test pod..."
-	kubectl delete pod nginx --ignore-not-found
-	sleep 2
-	kubectl run nginx --image=nginx
-	@echo "Waiting for pod to be ready..."
-	kubectl wait --for=condition=ready pod/nginx --timeout=30s
-	@echo "Checking pod labels..."
-	kubectl get pod nginx --show-labels
-
-.PHONY: debug
-debug:
-	@echo "Checking pod status..."
-	kubectl get pods -n pod-label-system
-	@echo "\nChecking deployment status..."
-	kubectl describe deployment pod-label-webhook -n pod-label-system
-	@echo "\nChecking events..."
-	kubectl get events -n pod-label-system --sort-by='.lastTimestamp'
-	@echo "\nChecking webhook logs..."
-	kubectl logs -n pod-label-system deployment/pod-label-webhook
-
-.PHONY: all
-all: build create-cluster load deploy
-	@echo "Waiting for system to stabilize..."
-	sleep 10
-	@echo "Setup complete. You can now run 'make test' to verify the webhook."
-
-.PHONY: redeploy
-redeploy: build load
-	kubectl delete -f manifests/deployment.yaml || true
-	kubectl delete -f manifests/webhook.yaml || true
-	sleep 5
-	make deploy
-
-# Test targets
-.PHONY: test-unit
-test-unit:
-	@echo "Running unit tests..."
-	go test ./pkg/webhook -v -count=1 -short
-
-.PHONY: test-integration-debug
-test-integration-debug:
-	@echo "Running integration tests with debug output..."
-	go test ./pkg/webhook -v -count=1 -tags=integration -run TestWebhookIntegration -timeout 10m
-
-.PHONY: test-integration
-test-integration:
-	@echo "Running integration tests..."
-	-go test ./pkg/webhook -v -count=1 -tags=integration -run TestWebhookIntegration
-	@echo "Cleaning up..."
-	$(MAKE) clean-test
-
-.PHONY: test-coverage
-test-coverage:
-	@echo "Running tests with coverage..."
-	go test ./pkg/webhook -v -count=1 -short -coverprofile=coverage.out
-	go tool cover -html=coverage.out -o coverage.html
-	@echo "Coverage report generated in coverage.html"
-
-.PHONY: test-all
-test-all: clean-test test-unit test-coverage test-integration
-	@echo "All tests completed"
-
-.PHONY: clean-test
-clean-test:
-	@echo "Cleaning up test artifacts..."
-	-kind delete cluster --name webhook-test 2>/dev/null || true
-	-rm -f coverage.out coverage.html
-	@echo "Test cleanup completed"
+	@echo "  build          - Build using goreleaser"
+	@echo "  test           - Run unit tests"
+	@echo "  test-integration - Run integration tests"
+	@echo "  clean          - Clean build artifacts"
+	@echo "  docker-build   - Build Docker image using goreleaser"
+	@echo "  docker-push    - Push Docker image to registry"
+	@echo "  dev-setup     - Create Kind cluster with cert-manager"
+	@echo "  dev-cleanup   - Delete Kind cluster"
+	@echo "  deploy        - Deploy webhook to cluster"
+	@echo "  dev-build     - Build and load image into Kind"
+	@echo "  undeploy      - Remove webhook from cluster"
+	@echo "  lint          - Run Go linting"
+	@echo "  lint-yaml     - Run YAML linting"
+	@echo "  lint-all      - Run all linting checks"
+	@echo "  verify        - Run all checks (linting and tests)"

--- a/Readme.md
+++ b/Readme.md
@@ -1,45 +1,31 @@
 # Pod Label Webhook
 
-A Kubernetes admission controller that automatically adds the label `hello=world` to every pod created in non-system namespaces. Built with Go and uses cert-manager for TLS certificate management.
+A Kubernetes admission webhook that automatically adds labels to pods during creation.
 
-## Project Structure
+## Overview
 
-```
-pod-label-webhook/
-├── .github/
-│   ├── dependabot.yml       # Dependency update configuration
-│   └── workflows/           # GitHub Actions workflows
-│       ├── go.yml          # Main Go workflow
-│       ├── quality.yml     # Code quality checks
-│       ├── release.yml     # Release automation
-│       └── security.yml    # Security scanning
-├── .gitignore              # Git ignore file
-├── .goreleaser.yml         # Release configuration
-├── .yamllint.yml          # YAML linting configuration
-├── Dockerfile             # Container image build instructions
-├── Makefile              # Build and deployment automation
-├── README.md             # This file
-├── go.mod               # Go module definition
-├── manifests/
-│   ├── deployment.yaml    # Webhook deployment and service
-│   ├── kind-config.yaml   # Kind cluster configuration
-│   └── webhook.yaml       # Certificate and webhook configuration
-└── pkg/
-    └── webhook/
-        ├── cmd/
-        │   └── main.go    # Entry point
-        └── webhook.go     # Main webhook logic
-```
+This webhook intercepts pod creation requests in Kubernetes and adds a "hello: world" label to all pods. It's built using the Kubernetes admission webhook framework and can be deployed as a standalone service in your cluster.
+
+## Features
+
+- Automatically labels pods during creation
+- Secure TLS communication using cert-manager
+- Configurable logging levels and formats
+- Kubernetes native deployment
+- Multi-architecture support (amd64, arm64)
 
 ## Prerequisites
 
-- Go 1.21+
+- Go 1.23+
 - Docker
-- Kind (Kubernetes in Docker)
+- Kind (for local development)
 - kubectl
-- make
+- goreleaser
+- cert-manager
 
-## Quick Start
+## Installation
+
+### Local Development
 
 1. Clone the repository:
 ```bash
@@ -47,252 +33,97 @@ git clone https://github.com/jjshanks/pod-label-webhook.git
 cd pod-label-webhook
 ```
 
-2. Create a test cluster and deploy the webhook:
+2. Set up a local Kind cluster with cert-manager:
 ```bash
-make build           # Build the webhook image
-make create-cluster  # Create Kind cluster and install cert-manager
-make load           # Load the image into Kind
-make deploy         # Deploy the webhook
+make dev-setup
 ```
 
-3. Test the webhook:
+3. Build and load the webhook image:
 ```bash
-make test           # Creates a test pod to verify labeling
+make dev-build
 ```
 
-## Development
-
-### Available Make Commands
-
-- `make help` - Show available commands
-- `make create-cluster` - Creates a Kind cluster and installs cert-manager
-- `make delete-cluster` - Deletes the Kind cluster
-- `make build` - Builds the webhook Docker image
-- `make load` - Loads the webhook image into Kind cluster
-- `make deploy` - Deploys the webhook to the cluster
-- `make test` - Creates a test pod to verify webhook
-- `make debug` - Shows status of webhook deployment
-- `make test-unit` - Runs unit tests
-- `make test-integration` - Runs integration tests
-- `make test-integration-debug` - Runs integration tests with debug output
-- `make test-coverage` - Generates test coverage report
-- `make test-all` - Runs all tests (unit, integration, coverage)
-- `make clean-test` - Cleans up test artifacts
-
-### GitHub Workflows
-
-#### Main Go Workflow (`go.yml`)
-- Runs on pull requests (excluding documentation changes)
-- Formats Go code and organizes imports
-- Runs Go vet checks
-- Runs unit tests with race detection
-- Generates coverage report
-- Runs integration tests (on Dependabot PRs or PRs labeled with 'integration-test')
-- Automatically commits code formatting changes
-- Notifies on failures through PR comments
-
-#### Quality Checks (`quality.yml`) 
-- Runs on pull requests (excluding documentation changes)
-- golangci-lint for Go code (only reports new issues)
-- Strict YAML validation with yamllint
-- Kubernetes manifest validation with kubeconform
-- Enforces strict validation modes
-
-#### Security Scanning (`security.yml`)
-- Runs on:
-  - Push to main branch
-  - Pull requests
-  - Weekly scheduled scans (Sundays)
-- Multiple security scanners:
-  - Gosec for Go security issues
-  - Trivy for filesystem and container scanning
-  - Anchore for container security analysis
-- Results uploaded to GitHub Security tab
-- Provides scan summaries in workflow logs
-
-#### Release Automation (`release.yml`)
-- Triggered by semantic version tags (v*.*.*)
-- Creates GitHub releases with automated release notes
-- Builds multi-arch container images (amd64, arm64)
-- Publishes to GitHub Container Registry
-- Automatically updates release documentation
-- Uses GoReleaser for consistent releases
-
-### Dependabot Configuration
-
-Automatically updates:
-- Go dependencies
-- GitHub Actions
-- Docker base images
-
-Dependencies are checked weekly and updated via pull requests:
-- Integration tests run automatically on Dependabot PRs
-- Updates are grouped by ecosystem to reduce noise
-- Security updates have higher priority
-
-### Testing
-
-The project includes several types of tests:
-
-#### Unit Tests
+4. Deploy the webhook:
 ```bash
-make test-unit
+make deploy
 ```
-Tests the webhook logic with race detection and generates coverage reports.
 
-#### Integration Tests
+### Production Deployment
+
+The webhook can be installed using the provided Kubernetes manifests:
+
 ```bash
-make test-integration
+kubectl create namespace pod-label-system
+kubectl apply -f manifests/
 ```
-Creates a test cluster and verifies the entire system works together.
-Note: Runs automatically on:
-- Dependabot pull requests
-- Pull requests labeled with 'integration-test'
 
-#### Coverage Report
+Pre-built images are available from GitHub Container Registry:
 ```bash
-make test-coverage
-```
-Generates a test coverage report in HTML format.
-Coverage reports are automatically uploaded as artifacts in GitHub Actions.
-
-### Common Tasks
-
-#### Adding New Labels
-Modify the `createPatch` function in `pkg/webhook/webhook.go`:
-```go
-func createPatch(pod *corev1.Pod) ([]byte, error) {
-    var patch []patchOperation
-    labels := map[string]string{
-        "hello": "world",
-        // Add more labels here
-        "new-label": "value",
-    }
-    // ... rest of the function
-}
-```
-
-#### Modifying Namespace Exclusions
-Update the `namespaceSelector` in `manifests/webhook.yaml`:
-```yaml
-namespaceSelector:
-  matchExpressions:
-  - key: kubernetes.io/metadata.name
-    operator: NotIn
-    values: 
-    - kube-system
-    - cert-manager
-    - pod-label-system
-    # Add more namespaces here
+ghcr.io/jjshanks/pod-label-webhook:latest
 ```
 
 ## Configuration
 
-### Webhook Configuration
-- Port: 8443
-- Certificate Path: `/etc/webhook/certs`
-- Excluded Namespaces: kube-system, cert-manager, pod-label-system
+The webhook supports the following configuration options:
 
-### Certificates
-- Managed by cert-manager
-- Auto-renewed
-- Stored in Kubernetes secrets
+| Flag | Environment Variable | Default | Description |
+|------|---------------------|---------|-------------|
+| --address | WEBHOOK_ADDRESS | 0.0.0.0:8443 | The address to listen on |
+| --log-level | WEBHOOK_LOG_LEVEL | info | Log level (trace, debug, info, warn, error, fatal, panic) |
+| --console | WEBHOOK_CONSOLE | false | Use console log format instead of JSON |
+| --config | - | $HOME/.webhook.yaml | Path to config file |
 
-## Releases
+## Development
 
-To create a new release:
-1. Create and push a tag following semantic versioning:
-```bash
-git tag -a v1.0.0 -m "Release v1.0.0"
-git push origin v1.0.0
+### Project Structure
+```
+├── pkg/webhook/      # Core webhook implementation
+│   ├── cmd/         # Command line interface
+│   ├── webhook.go   # Main webhook logic
+│   └── *_test.go    # Tests
+├── manifests/       # Kubernetes deployment manifests
+└── Dockerfile       # Container build definition
 ```
 
+### Available Make Targets
+
+- `make build` - Build using goreleaser
+- `make test` - Run unit tests
+- `make test-integration` - Run integration tests
+- `make clean` - Clean build artifacts
+- `make docker-build` - Build Docker image using goreleaser
+- `make docker-push` - Push Docker image to registry
+- `make dev-setup` - Create Kind cluster with cert-manager
+- `make dev-cleanup` - Delete Kind cluster
+- `make deploy` - Deploy webhook to cluster
+- `make dev-build` - Build and load image into Kind
+- `make undeploy` - Remove webhook from cluster
+- `make lint` - Run Go linting
+- `make lint-yaml` - Run YAML linting
+- `make verify` - Run all checks (linting and tests)
+
+### Release Process
+
+Releases are automated using GitHub Actions. To create a new release:
+
+1. Create and push a new tag following semantic versioning:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+   
 2. The release workflow will automatically:
-- Create a GitHub release
-- Build and push multi-arch container images
-- Generate release notes
-- Create binary artifacts
-- Update documentation
+   - Build multi-architecture binaries
+   - Create Docker images
+   - Publish the release on GitHub
+   - Push images to GitHub Container Registry
+
+Alternatively, you can trigger a manual release through the GitHub Actions UI.
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch
-3. Add tests for new functionality
-4. Ensure all tests pass: `make test-all`
-5. Ensure code quality checks pass
-6. Ensure security scans pass
-7. Submit a pull request
-
-Note: Integration tests will run automatically if you add the 'integration-test' label to your PR.
+Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## License
 
-MIT
-
-## AI Assistance
-
-If you want to work on this project with an AI assistant, you can use the following prompt:
-
-```
-I'm working on a Kubernetes admission controller project that adds the label "hello=world" to every pod. The project structure is:
-
-/pod-label-webhook
-  /pkg
-    /webhook
-      /cmd
-        main.go         # Entry point
-      webhook.go        # Main webhook logic
-  /manifests
-    deployment.yaml    # Webhook deployment and service
-    webhook.yaml       # Certificate and webhook configuration
-    kind-config.yaml   # Kind cluster configuration
-  Dockerfile          # Multi-stage build
-  Makefile           # Build automation
-  go.mod             # Go module file
-
-The project uses:
-- Go 1.21+ for implementation
-- cert-manager for TLS certificate management
-- kind for local testing
-- Make for build automation
-- Docker for containerization
-
-The webhook:
-- Adds hello=world label to all pods
-- Uses cert-manager for TLS
-- Excludes system namespaces (kube-system, cert-manager, pod-label-system)
-- Implements MutatingWebhookConfiguration
-
-I need help with [specific task/issue]. Can you assist with [specific question]?
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. `make deploy` fails:
-   - Ensure cert-manager is running: `kubectl get pods -n cert-manager`
-   - Check webhook logs: `kubectl logs -n pod-label-system deployment/pod-label-webhook`
-   - Verify certificates: `kubectl get certificate -n pod-label-system`
-
-2. Test pod not getting labeled:
-   - Check webhook is running: `make debug`
-   - Verify namespace is not excluded
-   - Check webhook logs for errors
-
-3. Integration tests fail:
-   - Ensure no existing test clusters: `make clean-test`
-   - Try debug mode: `make test-integration-debug`
-   - Check system resources
-
-4. GitHub Actions failing:
-   - Check golangci-lint output for new issues
-   - Verify YAML files pass strict validation
-   - Ensure Kubernetes manifests are valid
-   - Review security scan results in GitHub Security tab
-   - Check workflow logs for specific errors
-   - For dependabot PRs, verify integration tests are passing
-   - Ensure all quality checks pass before merging
-   - Address high severity security findings
-   - Verify tag format for releases (v*.*.*)
+This project is licensed under the terms in the LICENSE file.

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: webhook
           image: ghcr.io/jjshanks/pod-label-webhook:latest
-          imagePullPolicy: Never # Added this line for local images
+          imagePullPolicy: Never
           ports:
             - containerPort: 8443
           resources:

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: pod-label-webhook:latest
-          imagePullPolicy: Never  # Added this line for local images
+          image: ghcr.io/jjshanks/pod-label-webhook:latest
+          imagePullPolicy: Never # Added this line for local images
           ports:
             - containerPort: 8443
           resources:

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/jjshanks/pod-label-webhook:latest
+          image: ghcr.io/jjshanks/pod-label-webhook:$(VERSION)
           imagePullPolicy: Never
           ports:
             - containerPort: 8443


### PR DESCRIPTION
Update project tooling and documentation:
- Switch all docker builds to use goreleaser for consistency
- Add project-specific Kind cluster name 'add-label-webhook'
- Fix manifests deployment order to handle cert-manager dependencies
- Update deployment image to use ghcr.io repository
- Add comprehensive README with installation and development guides

The main improvements focus on:
1. Development workflow using Kind and cert-manager
2. Consistent build process via goreleaser
3. Clear documentation for setup and configuration

## Summary by Sourcery

Update the project to use goreleaser for building and deploying the webhook, and improve the local development workflow with Kind.

Enhancements:
- Simplify the Makefile and improve local development workflow.

Build:
- Use goreleaser for building Docker images and creating releases.

CI:
- Update the CI workflow to use goreleaser.

Deployment:
- Update the deployment image to use ghcr.io repository.

Documentation:
- Add a comprehensive README with installation and development guides.