### PR TITLE
feat: improve webhook configuration and deployment

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,8 +9,9 @@ on:
       - 'LICENSE'
 
 permissions:
-  contents: read
+  contents: write # Required for pushing format fixes
   security-events: write # Required for uploading code scanning results
+  pull-requests: write  # Required for pushing format fixes
   
 jobs:
   quality:
@@ -28,6 +29,47 @@ jobs:
         with:
           go-version: '1.21'
           cache: true
+
+      - name: Install tools
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
+          go install mvdan.cc/gofumpt@latest
+      
+      - name: Verify formatting and imports
+        id: verify
+        run: |
+          # Run format check
+          NEEDS_FORMAT=false
+          find . -name '*.go' -type f -print0 | xargs -0 gofumpt -l > fmt.out
+          if [ -s fmt.out ]; then
+            echo "Some files need formatting"
+            NEEDS_FORMAT=true
+            find . -name '*.go' -type f -print0 | xargs -0 gofumpt -w
+          fi
+          echo "needs_formatting=$NEEDS_FORMAT" >> $GITHUB_OUTPUT
+
+          # Run imports check
+          NEEDS_IMPORTS=false
+          find . -name '*.go' -type f -print0 | xargs -0 goimports -l > imports.out
+          if [ -s imports.out ]; then
+            echo "Some files need import organization"
+            NEEDS_IMPORTS=true
+            find . -name '*.go' -type f -print0 | xargs -0 goimports -w
+          fi
+          echo "needs_organization=$NEEDS_IMPORTS" >> $GITHUB_OUTPUT
+
+      - name: Commit changes if needed
+        if: steps.verify.outputs.needs_formatting == 'true' || steps.verify.outputs.needs_organization == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          git commit -m "chore: format Go code"
+          git fetch origin
+          git push origin HEAD:${BRANCH_NAME}
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ vendor/
 
 # goreleaser
 dist
+
+# AI
+flat/

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,5 +1,4 @@
 # manifests/deployment.yaml
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,7 +17,17 @@ spec:
       containers:
         - name: webhook
           image: ghcr.io/jjshanks/pod-label-webhook:$(VERSION)
-          imagePullPolicy: Never
+          imagePullPolicy: Always
+          args:
+            - "--cert-file=/tls/tls.crt"
+            - "--key-file=/tls/tls.key"
+          env:
+            - name: WEBHOOK_LOG_LEVEL
+              value: "info"
+            - name: WEBHOOK_CERT_FILE
+              value: "/tls/tls.crt"
+            - name: WEBHOOK_KEY_FILE
+              value: "/tls/tls.key"
           ports:
             - containerPort: 8443
           resources:
@@ -30,7 +39,7 @@ spec:
               cpu: "250m"
           volumeMounts:
             - name: cert
-              mountPath: /etc/webhook/certs
+              mountPath: /tls
               readOnly: true
       volumes:
         - name: cert

--- a/pkg/webhook/cmd/main.go
+++ b/pkg/webhook/cmd/main.go
@@ -18,6 +18,8 @@ var (
 	address  string
 	logLevel string
 	console  bool
+	certFile string
+	keyFile  string
 	rootCmd  = &cobra.Command{
 		Use:   "webhook",
 		Short: "Kubernetes admission webhook for pod labeling",
@@ -59,7 +61,12 @@ var (
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return webhook.Run(address)
+			config := webhook.Config{
+				CertFile: certFile,
+				KeyFile:  keyFile,
+				Address:  address,
+			}
+			return webhook.Run(config)
 		},
 	}
 )
@@ -77,10 +84,18 @@ func init() {
 
 	// Local flags for the root command
 	rootCmd.Flags().StringVar(&address, "address", "0.0.0.0:8443", "The address and port to listen on (e.g., 0.0.0.0:8443)")
+	rootCmd.Flags().StringVar(&certFile, "cert-file", "/etc/webhook/certs/tls.crt", "Path to the TLS certificate file")
+	rootCmd.Flags().StringVar(&keyFile, "key-file", "/etc/webhook/certs/tls.key", "Path to the TLS key file")
 
 	// Bind flags to viper
 	if err := viper.BindPFlag("address", rootCmd.Flags().Lookup("address")); err != nil {
 		log.Fatal().Err(err).Msg("Error binding address flag")
+	}
+	if err := viper.BindPFlag("cert-file", rootCmd.Flags().Lookup("cert-file")); err != nil {
+		log.Fatal().Err(err).Msg("Error binding cert-file flag")
+	}
+	if err := viper.BindPFlag("key-file", rootCmd.Flags().Lookup("key-file")); err != nil {
+		log.Fatal().Err(err).Msg("Error binding key-file flag")
 	}
 	if err := viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level")); err != nil {
 		log.Fatal().Err(err).Msg("Error binding log-level flag")
@@ -124,17 +139,19 @@ func initConfig() {
 		}
 	}
 
-	// Update the address from viper if it's set
+	// Update the values from viper if they're set
 	if viper.IsSet("address") {
 		address = viper.GetString("address")
 	}
-
-	// Update log level from viper if it's set
+	if viper.IsSet("cert-file") {
+		certFile = viper.GetString("cert-file")
+	}
+	if viper.IsSet("key-file") {
+		keyFile = viper.GetString("key-file")
+	}
 	if viper.IsSet("log-level") {
 		logLevel = viper.GetString("log-level")
 	}
-
-	// Update console output from viper if it's set
 	if viper.IsSet("console") {
 		console = viper.GetBool("console")
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -22,17 +23,17 @@ var (
 	runtimeScheme = runtime.NewScheme()
 	codecs        = serializer.NewCodecFactory(runtimeScheme)
 	deserializer  = codecs.UniversalDeserializer()
-
-	// Define a strict allowlist of valid certificate paths
-	allowedCertPaths = map[string]bool{
-		"/etc/webhook/certs/tls.crt": true,
-		"/etc/webhook/certs/tls.key": true,
-	}
 )
 
 func init() {
 	_ = corev1.AddToScheme(runtimeScheme)
 	_ = admissionv1.AddToScheme(runtimeScheme)
+}
+
+type Config struct {
+	CertFile string
+	KeyFile  string
+	Address  string
 }
 
 type patchOperation struct {
@@ -153,18 +154,9 @@ func handleMutate(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func Run(address string) error {
-	certPath := "/etc/webhook/certs/tls.crt"
-	keyPath := "/etc/webhook/certs/tls.key"
-
-	if !allowedCertPaths[certPath] {
-		return fmt.Errorf("certificate path not in allowlist: %s", certPath)
-	}
-	if !allowedCertPaths[keyPath] {
-		return fmt.Errorf("key path not in allowlist: %s", keyPath)
-	}
-
-	certInfo, err := os.Stat(certPath)
+func validateCertPaths(certFile, keyFile string) error {
+	// Validate certificate file
+	certInfo, err := os.Stat(certFile)
 	if err != nil {
 		return fmt.Errorf("certificate file error: %v", err)
 	}
@@ -172,7 +164,8 @@ func Run(address string) error {
 		return fmt.Errorf("certificate path is not a regular file")
 	}
 
-	keyInfo, err := os.Stat(keyPath)
+	// Validate key file
+	keyInfo, err := os.Stat(keyFile)
 	if err != nil {
 		return fmt.Errorf("key file error: %v", err)
 	}
@@ -180,11 +173,50 @@ func Run(address string) error {
 		return fmt.Errorf("key path is not a regular file")
 	}
 
+	// Check key file permissions
+	keyMode := keyInfo.Mode()
+	if keyMode.Perm()&0077 != 0 {
+		return fmt.Errorf("key file %s has excessive permissions %v, expected 0600 or more restrictive",
+			keyFile, keyMode.Perm())
+	}
+	if keyMode.Perm() > 0600 {
+		log.Warn().Str("key_file", keyFile).Msgf("key file has permissive mode %v, recommend 0600", keyMode.Perm())
+	}
+
+	// Validate parent directories
+	certDir := filepath.Dir(certFile)
+	keyDir := filepath.Dir(keyFile)
+
+	certDirInfo, err := os.Stat(certDir)
+	if err != nil {
+		return fmt.Errorf("certificate directory error: %v", err)
+	}
+	if !certDirInfo.IsDir() {
+		return fmt.Errorf("certificate parent path is not a directory")
+	}
+
+	keyDirInfo, err := os.Stat(keyDir)
+	if err != nil {
+		return fmt.Errorf("key directory error: %v", err)
+	}
+	if !keyDirInfo.IsDir() {
+		return fmt.Errorf("key parent path is not a directory")
+	}
+
+	return nil
+}
+
+func Run(config Config) error {
+	// Validate certificate paths
+	if err := validateCertPaths(config.CertFile, config.KeyFile); err != nil {
+		return fmt.Errorf("certificate validation failed: %v", err)
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mutate", handleMutate)
 
 	server := &http.Server{
-		Addr:              address,
+		Addr:              config.Address,
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 		WriteTimeout:      10 * time.Second,
@@ -195,6 +227,11 @@ func Run(address string) error {
 		},
 	}
 
-	log.Info().Str("address", address).Msg("Starting webhook server")
-	return server.ListenAndServeTLS(certPath, keyPath)
+	log.Info().
+		Str("address", config.Address).
+		Str("cert_file", config.CertFile).
+		Str("key_file", config.KeyFile).
+		Msg("Starting webhook server")
+
+	return server.ListenAndServeTLS(config.CertFile, config.KeyFile)
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -175,11 +175,11 @@ func validateCertPaths(certFile, keyFile string) error {
 
 	// Check key file permissions
 	keyMode := keyInfo.Mode()
-	if keyMode.Perm()&0077 != 0 {
+	if keyMode.Perm()&0o077 != 0 {
 		return fmt.Errorf("key file %s has excessive permissions %v, expected 0600 or more restrictive",
 			keyFile, keyMode.Perm())
 	}
-	if keyMode.Perm() > 0600 {
+	if keyMode.Perm() > 0o600 {
 		log.Warn().Str("key_file", keyFile).Msgf("key file has permissive mode %v, recommend 0600", keyMode.Perm())
 	}
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -254,10 +254,10 @@ func TestValidateCertPaths(t *testing.T) {
 	certPath := filepath.Join(tmpDir, "tls.crt")
 	keyPath := filepath.Join(tmpDir, "tls.key")
 
-	if err := os.WriteFile(certPath, []byte("test-cert"), 0644); err != nil {
+	if err := os.WriteFile(certPath, []byte("test-cert"), 0o644); err != nil {
 		t.Fatalf("failed to create test cert: %v", err)
 	}
-	if err := os.WriteFile(keyPath, []byte("test-key"), 0600); err != nil {
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
 		t.Fatalf("failed to create test key: %v", err)
 	}
 
@@ -273,14 +273,14 @@ func TestValidateCertPaths(t *testing.T) {
 			name:      "valid paths and permissions",
 			certFile:  certPath,
 			keyFile:   keyPath,
-			keyMode:   0600,
+			keyMode:   0o600,
 			expectErr: false,
 		},
 		{
 			name:      "invalid cert path",
 			certFile:  "/nonexistent/cert",
 			keyFile:   keyPath,
-			keyMode:   0600,
+			keyMode:   0o600,
 			expectErr: true,
 			errMsg:    "certificate file error",
 		},
@@ -288,7 +288,7 @@ func TestValidateCertPaths(t *testing.T) {
 			name:      "invalid key path",
 			certFile:  certPath,
 			keyFile:   "/nonexistent/key",
-			keyMode:   0600,
+			keyMode:   0o600,
 			expectErr: true,
 			errMsg:    "key file error",
 		},
@@ -296,7 +296,7 @@ func TestValidateCertPaths(t *testing.T) {
 			name:      "key too permissive (world readable)",
 			certFile:  certPath,
 			keyFile:   keyPath,
-			keyMode:   0644,
+			keyMode:   0o644,
 			expectErr: true,
 			errMsg:    "has excessive permissions",
 		},
@@ -304,7 +304,7 @@ func TestValidateCertPaths(t *testing.T) {
 			name:      "key too permissive (group readable)",
 			certFile:  certPath,
 			keyFile:   keyPath,
-			keyMode:   0640,
+			keyMode:   0o640,
 			expectErr: true,
 			errMsg:    "has excessive permissions",
 		},
@@ -312,14 +312,14 @@ func TestValidateCertPaths(t *testing.T) {
 			name:      "key minimally permissive",
 			certFile:  certPath,
 			keyFile:   keyPath,
-			keyMode:   0600,
+			keyMode:   0o600,
 			expectErr: false,
 		},
 		{
 			name:      "key more restrictive",
 			certFile:  certPath,
 			keyFile:   keyPath,
-			keyMode:   0400,
+			keyMode:   0o400,
 			expectErr: false,
 		},
 	}


### PR DESCRIPTION
- Add configuration struct for webhook settings
- Make TLS certificate paths configurable via flags and env vars
- Update deployment to mount certs at /tls
- Change version scheme to 0.0.1-SNAPSHOT-{git-commit}
- Add deployment readiness check
- Update dev-build to use goreleaser
- Improve certificate path validation

The webhook can now be configured more flexibly through command line flags and environment variables. Certificate handling is more robust with additional validation checks and configurable paths.

## Summary by Sourcery

Introduce configurable TLS certificate paths for the webhook server and update the deployment to mount certificates. Validate certificate and key file paths and permissions. Update the versioning scheme to include the Git commit SHA and use goreleaser for development builds. Add a readiness check to the deployment and update the CI to automatically format and organize Go code.

Enhancements:
- Make TLS certificate paths configurable via flags and environment variables.
- Improve certificate path validation.

Build:
- Use goreleaser for development builds.

CI:
- Add automatic formatting and import organization for Go code.

Deployment:
- Mount TLS certificates at /tls in the deployment.
- Add a readiness check to the deployment.

Tests:
- Add tests for certificate path validation.