### PR TITLE
ci: enable integ tests trigger via commit message

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -90,7 +90,9 @@ jobs:
     needs: verify
     if: |
       github.actor == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'integration-test')
+      contains(github.event.pull_request.labels.*.name, 'integration-test') ||
+      contains(github.event.pull_request.title, '#integ-test') ||
+      contains(join(github.event.pull_request.commits.*.message, ' '), '#integ-test')
     
     steps:
       - uses: actions/checkout@v4

--- a/Readme.md
+++ b/Readme.md
@@ -102,6 +102,14 @@ The webhook supports the following configuration options:
 - `make lint-yaml` - Run YAML linting
 - `make verify` - Run all checks (linting and tests)
 
+### Integration Tests
+
+Integration tests can be triggered in pull requests by:
+1. Adding the 'integration-test' label to the PR
+2. Including '#integ-test' in any commit message
+3. Including '#integ-test' in the PR title
+4. Automatically for Dependabot PRs
+
 ### Release Process
 
 Releases are automated using GitHub Actions. To create a new release:


### PR DESCRIPTION
Add ability to trigger integration tests by including '#integ-test' in commit messages or PR title. This provides more flexibility in when integration tests run, alongside the existing label-based trigger.

- Update Go workflow to check commit messages for '#integ-test'
- Add check for '#integ-test' in PR title
- Update README with documentation about integration test triggers
- Maintain existing triggers (labels and Dependabot)

This change makes it easier to run integration tests without requiring label modifications, which can be helpful when making changes that need integration testing but don't warrant a permanent label.

## Summary by Sourcery

Allow triggering integration tests by including "#integ-test" in commit messages or pull request titles, in addition to the existing label-based trigger.

CI:
- Add support for triggering integration tests via commit messages or PR titles containing "#integ-test".

Documentation:
- Document the new integration test trigger options in the README.