### PR TITLE
Add annotation to control label behavior

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -106,7 +106,7 @@ The webhook supports the following configuration options:
 
 ```
 ├── pkg/webhook/      # Core webhook implementation
-│   ├── cmd/         # Command line interface
+│   ├── cmd/         # Command Line Interface
 │   ├── webhook.go   # Main webhook logic
 │   └── *_test.go    # Tests
 ├── tests/           # Test resources

--- a/scripts/integ-test.sh
+++ b/scripts/integ-test.sh
@@ -2,13 +2,33 @@
 
 set -euo pipefail
 
-kubectl apply -f tests/manifests/test-deployment.yaml
-kubectl wait --for=condition=Available --timeout=60s -n default deployment/integ-test
+# Cleanup function
+cleanup() {
+    echo "Cleaning up test resources..."
+    kubectl delete -f tests/manifests/test-deployment.yaml --ignore-not-found
+}
 
-if kubectl get pods -n default -l app=integ-test,hello=world --no-headers 2>/dev/null | grep -q .; then
-    echo "Label exists"
-    exit 0
-else
-    echo "Label not found"
+# Set up cleanup on script exit
+trap cleanup EXIT
+
+echo "Applying test deployments..."
+kubectl apply -f tests/manifests/test-deployment.yaml
+
+echo "Waiting for deployments to be available..."
+kubectl wait --for=condition=Available --timeout=60s -n default deployment/integ-test
+kubectl wait --for=condition=Available --timeout=60s -n default deployment/integ-test-no-label
+
+echo "Checking for expected label presence..."
+if ! kubectl get pods -n default -l app=integ-test,hello=world --no-headers 2>/dev/null | grep -q .; then
+    echo "ERROR: Label 'hello=world' not found when it should be present"
     exit 1
 fi
+
+echo "Checking for expected label absence..."
+if kubectl get pods -n default -l app=integ-test-no-label,hello=world --no-headers 2>/dev/null | grep -q .; then
+    echo "ERROR: Label 'hello=world' found when it should not be present"
+    exit 1
+fi
+
+echo "All tests passed successfully!"
+exit 0

--- a/tests/manifests/test-deployment.yaml
+++ b/tests/manifests/test-deployment.yaml
@@ -19,3 +19,27 @@ spec:
         - name: integ-test
           image: busybox
           command: ["sh", "-c", "sleep infinity"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integ-test-no-label
+  namespace: default
+  labels:
+    app: integ-test-no-label
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: integ-test-no-label
+  template:
+    metadata:
+      labels:
+        app: integ-test-no-label
+      annotations:
+        pod-label-webhook.jjshanks.github.com/add-hello-world: "false"
+    spec:
+      containers:
+        - name: integ-test-no-label
+          image: busybox
+          command: ["sh", "-c", "sleep infinity"]


### PR DESCRIPTION
Add a new annotation 'pod-label-webhook.jjshanks.github.com/add-hello-world' that allows users to disable the hello=world label when set to "false". Default behavior remains unchanged when annotation is missing or set to "true".

- Update webhook logic to check for annotation
- Add new test cases covering annotation behavior
- Update integration tests to verify both positive and negative cases
- Update documentation with annotation usage and examples

run-integ-test

## Summary by Sourcery

Add support for disabling the "hello=world" label via the `pod-label-webhook.jjshanks.github.com/add-hello-world` annotation.  Preserve existing pod labels when patching.

New Features:
- Added annotation support to control the addition of the "hello=world" label.  Setting the `pod-label-webhook.jjshanks.github.com/add-hello-world` annotation to "false" will prevent the label from being added.

Tests:
- Extended integration tests to verify the new annotation behavior, covering both positive and negative use cases.