### PR TITLE
refactor: move server logic into dedicated Server type

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -25,47 +25,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23"
           cache: true
-
-      - name: Install tools
-        run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-          go install mvdan.cc/gofumpt@latest
-
-      - name: Verify formatting and imports
-        id: verify
-        run: |
-          # Run format check
-          NEEDS_FORMAT=false
-          find . -name '*.go' -type f -print0 | xargs -0 gofumpt -l > fmt.out
-          if [ -s fmt.out ]; then
-            echo "Some files need formatting"
-            NEEDS_FORMAT=true
-            find . -name '*.go' -type f -print0 | xargs -0 gofumpt -w
-          fi
-          echo "needs_formatting=$NEEDS_FORMAT" >> $GITHUB_OUTPUT
-
-          # Run imports check
-          NEEDS_IMPORTS=false
-          find . -name '*.go' -type f -print0 | xargs -0 goimports -l > imports.out
-          if [ -s imports.out ]; then
-            echo "Some files need import organization"
-            NEEDS_IMPORTS=true
-            find . -name '*.go' -type f -print0 | xargs -0 goimports -w
-          fi
-          echo "needs_organization=$NEEDS_IMPORTS" >> $GITHUB_OUTPUT
-
-      - name: Commit changes if needed
-        if: steps.verify.outputs.needs_formatting == 'true' || steps.verify.outputs.needs_organization == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add .
-          git commit -m "chore: format Go code"
-          git push
 
       - name: Run go vet
         run: go vet ./...
@@ -98,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23"
           cache: true
 
       - name: Install GoReleaser

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,23 +2,24 @@ name: Quality
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
 
 permissions:
   contents: write # Required for pushing format fixes
   security-events: write # Required for uploading code scanning results
-  pull-requests: write  # Required for pushing format fixes
-  
+  pull-requests: write # Required for pushing format fixes
+  checks: write
+
 jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,60 +28,31 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: "1.23"
           cache: true
-
-      - name: Install tools
-        run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-          go install mvdan.cc/gofumpt@latest
-      
-      - name: Verify formatting and imports
-        id: verify
-        run: |
-          # Run format check
-          NEEDS_FORMAT=false
-          find . -name '*.go' -type f -print0 | xargs -0 gofumpt -l > fmt.out
-          if [ -s fmt.out ]; then
-            echo "Some files need formatting"
-            NEEDS_FORMAT=true
-            find . -name '*.go' -type f -print0 | xargs -0 gofumpt -w
-          fi
-          echo "needs_formatting=$NEEDS_FORMAT" >> $GITHUB_OUTPUT
-
-          # Run imports check
-          NEEDS_IMPORTS=false
-          find . -name '*.go' -type f -print0 | xargs -0 goimports -l > imports.out
-          if [ -s imports.out ]; then
-            echo "Some files need import organization"
-            NEEDS_IMPORTS=true
-            find . -name '*.go' -type f -print0 | xargs -0 goimports -w
-          fi
-          echo "needs_organization=$NEEDS_IMPORTS" >> $GITHUB_OUTPUT
-
-      - name: Commit changes if needed
-        if: steps.verify.outputs.needs_formatting == 'true' || steps.verify.outputs.needs_organization == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add .
-          git commit -m "chore: format Go code"
-          git fetch origin
-          git push origin HEAD:${BRANCH_NAME}
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          args: --timeout=5m
+          args: --timeout=5m --fix
           only-new-issues: true
           working-directory: ./pkg
 
+      - name: Commit changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config --global user.name 'GitHub Actions'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git add -A
+            git commit -m "chore: apply linter fixes"
+            git push
+          else
+            echo "No changes to commit"
+          fi
+
       - name: YAML lint
-        uses: ibiqlik/action-yamllint@v3.1 
+        uses: ibiqlik/action-yamllint@v3.1
         with:
           file_or_dir: tests/manifests/
           config_file: .yamllint.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version (e.g., v1.2.3, v1.2.3-beta.1, v1.2.3+meta.4)'
+        description: "Version (e.g., v1.2.3, v1.2.3-beta.1, v1.2.3+meta.4)"
         required: true
         type: string
       prerelease:
-        description: 'Is this a prerelease?'
+        description: "Is this a prerelease?"
         required: false
         type: boolean
         default: false
   push:
-    tags: [ 'v*.*.*' ]
+    tags: ["v*.*.*"]
 
 permissions:
   contents: write # Required for creating releases
@@ -29,7 +29,7 @@ jobs:
       - name: Check version format
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          
+
           # Check if version starts with 'v'
           if [[ ! "$VERSION" =~ ^v ]]; then
             echo "Error: Version must start with 'v'"
@@ -41,10 +41,10 @@ jobs:
             echo "  - v1.2.3+meta (release with build metadata)"
             exit 1
           fi
-          
+
           # Remove 'v' prefix for semver validation
           VERSION_WITHOUT_V="${VERSION#v}"
-          
+
           # Semver regex that supports pre-release and build metadata
           SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$"
           if ! echo "$VERSION_WITHOUT_V" | grep -E "$SEMVER_REGEX"; then
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: "1.23"
           cache: true # Enable Go modules cache
 
       - name: Login to GHCR
@@ -122,7 +122,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser # Use OSS version of GoReleaser
-          version: '~> v2'
+          version: "~> v2"
           args: release --clean # Clean before building
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
             } else {
               tag = context.ref.replace('refs/tags/', '');
             }
-            
+
             // Wait for the release to be available
             let release;
             for (let i = 0; i < 5; i++) {
@@ -158,10 +158,10 @@ jobs:
                 await new Promise(resolve => setTimeout(resolve, 5000));
               }
             }
-            
+
             // Add documentation link to release notes
             const releaseNotes = `## ${tag}\n\n${release.data.body}\n\n---\n\nFor installation instructions and documentation, please visit our [documentation](docs/README.md).`;
-            
+
             await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
 run:
   timeout: 5m
   tests: true
-  go: '1.21'
+  go: "1.23"
 
 linters-settings:
   goimports:

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/pkg/webhook/cmd/main.go
+++ b/pkg/webhook/cmd/main.go
@@ -33,7 +33,11 @@ var (
 			if err != nil {
 				return err
 			}
-			return webhook.Run(cfg)
+			server, err := webhook.NewServer(cfg)
+			if err != nil {
+				return err
+			}
+			return server.Run()
 		},
 	}
 )

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/jjshanks/pod-label-webhook/internal/config"
 	"github.com/rs/zerolog"
+
+	"github.com/jjshanks/pod-label-webhook/internal/config"
 )
 
 type Server struct {

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -1,0 +1,166 @@
+package webhook
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jjshanks/pod-label-webhook/internal/config"
+	"github.com/rs/zerolog"
+)
+
+type Server struct {
+	logger zerolog.Logger
+	config *config.Config
+}
+
+func NewServer(cfg *config.Config) (*Server, error) {
+	// Create base logger with common fields
+	logger := zerolog.New(os.Stdout).With().
+		Timestamp().
+		Str("service", "pod-label-webhook").
+		Logger()
+
+	// Configure log level
+	level, err := zerolog.ParseLevel(cfg.LogLevel)
+	if err != nil {
+		return nil, fmt.Errorf("invalid log level: %w", err)
+	}
+	logger = logger.Level(level)
+
+	// Configure console output if needed
+	if cfg.Console {
+		logger = logger.Output(zerolog.ConsoleWriter{
+			Out:        os.Stdout,
+			TimeFormat: "2006-01-02T15:04:05.000Z",
+		})
+	}
+
+	return &Server{
+		logger: logger,
+		config: cfg,
+	}, nil
+}
+
+func (s *Server) Run() error {
+	s.logger.Info().
+		Str("address", s.config.Address).
+		Str("cert_file", s.config.CertFile).
+		Str("key_file", s.config.KeyFile).
+		Msg("Starting webhook server")
+
+		// Validate certificate paths
+	if err := s.config.ValidateCertPaths(); err != nil {
+		return fmt.Errorf("certificate validation failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mutate", s.handleMutate)
+
+	server := &http.Server{
+		Addr:              s.config.Address,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			CipherSuites: []uint16{
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+				tls.TLS_CHACHA20_POLY1305_SHA256,
+			},
+			CurvePreferences: []tls.CurveID{
+				tls.X25519,
+				tls.CurveP384,
+			},
+			SessionTicketsDisabled: true,
+			Renegotiation:          tls.RenegotiateNever,
+			InsecureSkipVerify:     false,
+			ClientAuth:             tls.VerifyClientCertIfGiven,
+		},
+	}
+
+	s.logger.Info().
+		Str("address", s.config.Address).
+		Str("cert_file", s.config.CertFile).
+		Str("key_file", s.config.KeyFile).
+		Msg("Starting webhook server")
+
+	return server.ListenAndServeTLS(s.config.CertFile, s.config.KeyFile)
+}
+
+func (s *Server) validateCertPaths(certFile, keyFile string) error {
+	s.logger.Debug().Msg("Validating certificate paths")
+
+	// Validate certificate file
+	certInfo, err := os.Stat(certFile)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Certificate validation failed")
+		return fmt.Errorf("certificate file error: %v", err)
+	}
+	if !certInfo.Mode().IsRegular() {
+		s.logger.Error().Msg("Certificate validation failed")
+		return fmt.Errorf("certificate path is not a regular file")
+	}
+
+	// Validate key file
+	keyInfo, err := os.Stat(keyFile)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Certificate validation failed")
+		return fmt.Errorf("key file error: %v", err)
+	}
+	if !keyInfo.Mode().IsRegular() {
+		s.logger.Error().Msg("Certificate validation failed")
+		return fmt.Errorf("key path is not a regular file")
+	}
+
+	// Check key file permissions
+	keyMode := keyInfo.Mode()
+	if keyMode.Perm()&0o077 != 0 {
+		s.logger.Error().
+			Str("key_file", keyFile).
+			Str("mode", keyMode.String()).
+			Msg("Key file has excessive permissions")
+		s.logger.Error().Msg("Certificate validation failed")
+		return fmt.Errorf("key file %s has excessive permissions %v, expected 0600 or more restrictive",
+			keyFile, keyMode.Perm())
+	}
+	if keyMode.Perm() > 0o600 {
+		s.logger.Warn().
+			Str("key_file", keyFile).
+			Str("mode", keyMode.String()).
+			Msg("key file has permissive mode %v, recommend 0600")
+	}
+
+	// Validate parent directories
+	certDir := filepath.Dir(certFile)
+	keyDir := filepath.Dir(keyFile)
+
+	certDirInfo, err := os.Stat(certDir)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Certificate validation failed")
+		return fmt.Errorf("certificate directory error: %v", err)
+	}
+	if !certDirInfo.IsDir() {
+		s.logger.Error().Msg("Certificate validation failed")
+		return fmt.Errorf("certificate parent path is not a directory")
+	}
+
+	keyDirInfo, err := os.Stat(keyDir)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Certificate validation failed")
+		return fmt.Errorf("key directory error: %v", err)
+	}
+	if !keyDirInfo.IsDir() {
+		s.logger.Error().Msg("Certificate validation failed")
+		return fmt.Errorf("key parent path is not a directory")
+	}
+
+	s.logger.Debug().Msg("Certificate paths validated successfully")
+	return nil
+}


### PR DESCRIPTION
This commit restructures the webhook package by:
- Creating a new Server type to encapsulate webhook functionality
- Moving HTTP handler and cert validation into Server methods
- Adding structured logging with request IDs using zerolog
- Improving test coverage with log message verification
- Adding uuid dependency for request tracing
- Updating main.go to use new Server type

The changes improve code organization, testability, and observability while maintaining existing functionality.

run-integ-test

## Summary by Sourcery

Introduce a dedicated `Server` type to encapsulate webhook logic, enhancing code organization, testability, and observability. Implement structured logging with request IDs.

Enhancements:
- Encapsulate webhook functionality within a new `Server` type.

Tests:
- Improve test coverage, including verification of log messages.