### PR TITLE
fix(webhook): return error from GetAddr when server is not initialized

### DIFF
--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -173,11 +173,11 @@ func (s *Server) shutdown() error {
 }
 
 // GetAddr returns the server's current address in a thread-safe way
-func (s *Server) GetAddr() string {
+func (s *Server) GetAddr() (string, error) {
 	s.serverMu.RLock()
 	defer s.serverMu.RUnlock()
 	if s.server == nil {
-		return s.config.Address
+		return "", fmt.Errorf("server is not initialized")
 	}
-	return s.server.Addr
+	return s.server.Addr, nil
 }


### PR DESCRIPTION
Previously GetAddr would return the config address when the server was not initialized, which could be misleading as the actual listening address might be different. This change makes GetAddr return an error in this case to prevent confusion.

- Modified GetAddr to return (string, error) instead of just string
- Updated GetAddr to return error when server is nil
- Rewrote TestGetAddr to properly test both initialized and uninitialized cases
- Updated TestServerShutdownSignals to handle GetAddr errors
- Fixed cleanup and error handling in tests

This is a breaking change as it modifies the GetAddr signature.

run-integ-test

## Summary by Sourcery

Fix the GetAddr function to return an error when the server is not initialized, rather than returning the configured address.

Bug Fixes:
- Fixed an issue where GetAddr would return a potentially incorrect address when the server was not initialized.

Tests:
- Updated tests for GetAddr and server shutdown to handle the new error return.