### PR TITLE
feat: add label operation metrics and improve test structure

### DIFF
--- a/test/integration/utils.sh
+++ b/test/integration/utils.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# test/integration/utils.sh
+# Common utility functions for integration tests
+
+# Extract metric value using grep and awk
+get_metric_value() {
+    local metric_name=$1
+    local labels=$2
+    local metrics_output=$3
+    local value
+    
+    if [ -z "$labels" ]; then
+        # For metrics without labels (like gauges)
+        value=$(echo "$metrics_output" | grep "^$metric_name " | awk '{print $2}')
+    else
+        # For metrics with labels
+        value=$(echo "$metrics_output" | grep "^$metric_name{${labels}}" | awk '{print $2}')
+    fi
+    
+    # If no value found, print the matching lines for debugging
+    if [ -z "$value" ]; then
+        echo "DEBUG: Lines matching ${metric_name}:" >&2
+        echo "$metrics_output" | grep "^${metric_name}" >&2
+    fi
+    
+    echo "$value"
+}
+
+# Check metric with retries
+check_metric() {
+    local metric_name=$1
+    local labels=$2
+    local expected_min=$3
+    local description=$4
+    local metrics_port=$5
+    local max_attempts=10
+    local attempt=1
+    local value
+    local metrics_output
+
+    while [ $attempt -le $max_attempts ]; do
+        metrics_output=$(curl -sk https://localhost:${metrics_port}/metrics 2>/dev/null)
+        value=$(get_metric_value "$metric_name" "$labels" "$metrics_output")
+        
+        if [ -n "$value" ]; then
+            if awk "BEGIN {exit !($value >= $expected_min)}"; then
+                echo "✓ $description verified (value: $value)"
+                return 0
+            fi
+        fi
+        
+        echo "Attempt $attempt: Waiting for $description (current: ${value:-none}, expected min: $expected_min)"
+        sleep 5
+        attempt=$((attempt + 1))
+    done
+    
+    echo "ERROR: Failed to verify $description after $max_attempts attempts"
+    echo "Current metrics output:"
+    echo "$metrics_output"
+    return 1
+}
+
+# Wait for port to be available
+wait_for_port() {
+    local port=$1
+    local max_attempts=${2:-10}
+    local attempt=1
+
+    echo "Waiting for port $port to be available..."
+    while [ $attempt -le $max_attempts ]; do
+        if nc -z localhost "$port"; then
+            echo "Port $port is available"
+            return 0
+        fi
+        echo "Attempt $attempt: Port $port not available yet"
+        sleep 2
+        attempt=$((attempt + 1))
+    done
+
+    echo "ERROR: Port $port not available after $max_attempts attempts"
+    return 1
+}
+
+# Clean up resources and handle interrupts
+cleanup() {
+    echo "Cleaning up test resources..."
+    # Kill port forwarding if it exists
+    if [ -n "${PORT_FORWARD_PID:-}" ]; then
+        echo "Stopping port forwarding process..."
+        kill $PORT_FORWARD_PID || true
+        wait $PORT_FORWARD_PID 2>/dev/null || true
+    fi
+    # Delete test resources
+    echo "Deleting test deployments..."
+    kubectl delete -f test/e2e/manifests/test-deployment.yaml --ignore-not-found
+}


### PR DESCRIPTION
- Add new metrics for tracking label operations and annotations
  - pod_label_webhook_label_operations_total counter (success/skipped/error)
  - pod_label_webhook_annotation_validation_total counter (valid/invalid/missing)
- Update webhook code to record new metrics during pod mutation
- Add unit tests for new metrics
- Improve integration test structure:
  - Extract common test utilities to test/integration/utils.sh
  - Add retries and better error handling for metric checks
  - Fix label ordering in metric queries to match Prometheus output

The new metrics provide better visibility into webhook operations and the test improvements make the integration tests more reliable and maintainable.

run-integ-test

## Summary by Sourcery

Add metrics for label operations and annotation validation. Update the webhook to record these metrics. Improve integration tests by extracting common utilities, adding retries for metric checks, and fixing label ordering in metric queries.

New Features:
- Added `pod_label_webhook_label_operations_total` counter, which tracks the number of label operations by result (success, skipped, or error) and namespace.
- Added `pod_label_webhook_annotation_validation_total` counter, which tracks annotation validation results (valid, invalid, or missing) and namespace.

Tests:
- Improved integration test structure by extracting common utilities to `test/integration/utils.sh`.
- Added retries and better error handling for metric checks in integration tests.
- Fixed label ordering in metric queries within integration tests to match Prometheus output.