### PR TITLE
refactor: consolidate certificate generation for tests

### DIFF
--- a/internal/webhook/health_test.go
+++ b/internal/webhook/health_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -72,13 +71,9 @@ func setupTestServer(t *testing.T, clock Clock) *TestServer {
 	tempDir, err := os.MkdirTemp("", "webhook-test-")
 	require.NoError(t, err)
 
-	// Create test certificate files
-	certFile := filepath.Join(tempDir, "tls.crt")
-	keyFile := filepath.Join(tempDir, "tls.key")
-
-	// Generate self-signed certificate
-	err = generateSelfSignedCert(certFile, keyFile)
-	require.NoError(t, err)
+	testCfg := defaultTestCertConfig()
+	certFile, keyFile, cleanupCerts := generateTestCert(t, testCfg)
+	defer cleanupCerts()
 
 	// Get random available port
 	listener, err := net.Listen("tcp", "localhost:0")


### PR DESCRIPTION
Simplifies and consolidates the self-signed certificate generation for tests:
- Moves certificate configuration into testCertConfig struct
- Removes redundant generateSelfSignedCert function
- Adds generateTestCert with cleaner interface and cleanup handling
- Adds mockTLSServer helper for tests that don't need real certs
- Updates setupTestServer and related functions to use new helpers

Tests still maintain full coverage while reducing complexity and duplication in certificate handling. Makes it easier to mock TLS when not testing cert functionality directly.

run-integ-test

## Summary by Sourcery

Tests:
- Improve test setup and reduce code duplication by consolidating certificate generation.