### PR TITLE
refactor: improve test port allocation robustness

### DIFF
--- a/internal/webhook/health_test.go
+++ b/internal/webhook/health_test.go
@@ -1,8 +1,6 @@
 package webhook
 
 import (
-	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -75,15 +73,12 @@ func setupTestServer(t *testing.T, clock Clock) *TestServer {
 	certFile, keyFile, cleanupCerts := generateTestCert(t, testCfg)
 	defer cleanupCerts()
 
-	// Get random available port
-	listener, err := net.Listen("tcp", "localhost:0")
-	require.NoError(t, err)
-	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close()
+	addr, portCleanup := GetTestAddr(t)
+	defer portCleanup()
 
 	// Create test configuration with temp certificate paths and random port
 	cfg := &config.Config{
-		Address:  fmt.Sprintf("localhost:%d", port),
+		Address:  addr,
 		CertFile: certFile,
 		KeyFile:  keyFile,
 		LogLevel: "debug",


### PR DESCRIPTION
- Add portAllocator struct to manage test port allocation
- Implement thread-safe port tracking with mutex protection
- Add retry logic and port verification
- Replace direct port allocation with GetTestAddr helper
- Update affected tests in health_test.go and server_test.go

The new port allocation system prevents test flakiness by:
- Tracking and cleaning up used ports
- Verifying ports are truly available before use
- Providing consistent port allocation across test files
- Adding timeouts and retries for system port assignment

run-integ-test

## Summary by Sourcery

Tests:
- Improve test robustness by preventing flaky tests caused by port conflicts.