### PR TITLE
Fix golangci-lint errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,11 +202,11 @@ func LoadConfig(cfgFile string) (*Config, error) {
 		}
 		if viper.IsSet("console") {
 			rawValue := viper.Get("console")
-			switch rawValue.(type) {
+			switch v := rawValue.(type) {
 			case bool:
 				// This is fine
 			case string:
-				if _, err := strconv.ParseBool(rawValue.(string)); err != nil {
+				if _, err := strconv.ParseBool(v); err != nil {
 					return nil, fmt.Errorf("error unmarshaling config: console must be a boolean")
 				}
 			default:

--- a/internal/webhook/error.go
+++ b/internal/webhook/error.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 )
 
-// WebhookError represents an error that occurred during webhook processing.
+// Error represents an error that occurred during webhook processing.
 // It provides context about the operation that failed and the resource being processed.
 // The error implements the error interface and supports error wrapping for
 // maintaining error chains.
-type WebhookError struct {
+type Error struct {
 	Op   string // The operation that failed (e.g., "decode", "validate", "patch")
 	Path string // Resource path or identifier (e.g., "pod/my-pod")
 	Err  error  // The underlying error that caused the failure
@@ -19,7 +19,7 @@ type WebhookError struct {
 // Error implements the error interface.
 // It formats the error message to include the operation, resource path (if any),
 // and underlying error details.
-func (e *WebhookError) Error() string {
+func (e *Error) Error() string {
 	if e.Path != "" {
 		return fmt.Sprintf("webhook %s failed for %s: %v", e.Op, e.Path, e.Err)
 	}
@@ -29,7 +29,7 @@ func (e *WebhookError) Error() string {
 // Unwrap implements the error unwrapping interface.
 // It returns the underlying error to support error chains and
 // work with errors.Is and errors.As.
-func (e *WebhookError) Unwrap() error {
+func (e *Error) Unwrap() error {
 	return e.Err
 }
 
@@ -40,7 +40,7 @@ func (e *WebhookError) Unwrap() error {
 // newDecodeError creates an error for JSON decoding failures.
 // Used when unmarshaling admission reviews or pod specifications fails.
 func newDecodeError(err error, resourcePath string) error {
-	return &WebhookError{
+	return &Error{
 		Op:   "decode",
 		Path: resourcePath,
 		Err:  err,
@@ -50,7 +50,7 @@ func newDecodeError(err error, resourcePath string) error {
 // newValidationError creates an error for validation failures.
 // Used when pod specifications or configurations fail validation checks.
 func newValidationError(err error, resourcePath string) error {
-	return &WebhookError{
+	return &Error{
 		Op:   "validate",
 		Path: resourcePath,
 		Err:  err,
@@ -60,7 +60,7 @@ func newValidationError(err error, resourcePath string) error {
 // newPatchError creates an error for patch creation or application failures.
 // Used when generating or applying JSON patches to pods fails.
 func newPatchError(err error, resourcePath string) error {
-	return &WebhookError{
+	return &Error{
 		Op:   "patch",
 		Path: resourcePath,
 		Err:  err,

--- a/internal/webhook/metrics_test.go
+++ b/internal/webhook/metrics_test.go
@@ -286,8 +286,8 @@ func TestMetricsMiddleware(t *testing.T) {
 
 			// Verify error counter for error cases
 			if tt.statusCode >= 400 {
-				errCounter, err := m.errorCounter.GetMetricWith(tt.expectedLabels)
-				require.NoError(t, err)
+				errCounter, errCounterErr := m.errorCounter.GetMetricWith(tt.expectedLabels)
+				require.NoError(t, errCounterErr)
 				assert.Equal(t, float64(1), extractMetricValue(errCounter))
 			}
 

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -564,8 +564,8 @@ func TestServerShutdownSignals(t *testing.T) {
 					continue
 				}
 
-				resp, err := client.Get(fmt.Sprintf("https://%s/healthz", addr))
-				if err == nil {
+				resp, healthErr := client.Get(fmt.Sprintf("https://%s/healthz", addr))
+				if healthErr == nil {
 					resp.Body.Close()
 					if resp.StatusCode == http.StatusOK {
 						break
@@ -577,10 +577,10 @@ func TestServerShutdownSignals(t *testing.T) {
 
 			// Send shutdown signal
 			t.Logf("Sending %s signal...", tc.name)
-			p, err := os.FindProcess(os.Getpid())
-			require.NoError(t, err)
-			err = p.Signal(tc.signal)
-			require.NoError(t, err)
+			p, processErr := os.FindProcess(os.Getpid())
+			require.NoError(t, processErr)
+			signalErr := p.Signal(tc.signal)
+			require.NoError(t, signalErr)
 
 			// Wait for shutdown
 			select {
@@ -593,8 +593,8 @@ func TestServerShutdownSignals(t *testing.T) {
 			wg.Wait()
 
 			// Verify server is no longer accepting connections
-			_, err = client.Get(fmt.Sprintf("https://%s/healthz", addr))
-			assert.Error(t, err)
+			_, healthErr := client.Get(fmt.Sprintf("https://%s/healthz", addr))
+			assert.Error(t, healthErr)
 		})
 	}
 }
@@ -635,7 +635,7 @@ func TestServerShutdownTimeout(t *testing.T) {
 	// Start server listener in a goroutine
 	go func() {
 		close(serverStarted)
-		err := srv.server.ListenAndServeTLS(srv.config.CertFile, srv.config.KeyFile)
+		err = srv.server.ListenAndServeTLS(srv.config.CertFile, srv.config.KeyFile)
 		if err != nil && err != http.ErrServerClosed {
 			serverStopped <- err
 		}

--- a/internal/webhook/webhook_fuzz_test.go
+++ b/internal/webhook/webhook_fuzz_test.go
@@ -73,7 +73,7 @@ func FuzzCreatePatch(f *testing.F) {
 		patch, err := ts.createPatch(pod)
 
 		if err != nil {
-			if _, ok := err.(*WebhookError); !ok {
+			if _, ok := err.(*Error); !ok {
 				t.Errorf("unexpected error type: %T", err)
 			}
 			return


### PR DESCRIPTION
## Summary by Sourcery

Fixes golangci-lint errors by renaming variables, updating error handling, and correcting error types.

Enhancements:
- Renames the WebhookError type to Error.
- Updates error handling in the mutate handler to use a local variable instead of shadowing the outer err variable.
- Updates the console config parsing to avoid type assertion panics.
- Updates the metrics middleware to use a local variable instead of shadowing the outer err variable.
- Updates the server shutdown signals test to use local variables instead of shadowing the outer err variable.