### PR TITLE
Upgrade to go 1.24.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/jjshanks/pod-label-webhook
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	github.com/prometheus/client_golang v1.21.1


### PR DESCRIPTION
run-integ-test

## Summary by Sourcery

Build:
- Update go.mod to use go 1.24.1