### PR TITLE
Rename project from pod-label-webhook to add-pod-label

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,8 @@ builds:
 
 dockers:
   - image_templates:
-      - "ghcr.io/jjshanks/pod-label-webhook:{{ .Version }}"
-      - "ghcr.io/jjshanks/pod-label-webhook:latest"
+      - "ghcr.io/jjshanks/add-pod-label:{{ .Version }}"
+      - "ghcr.io/jjshanks/add-pod-label:latest"
     dockerfile: goreleaser.dockerfile
     use: buildx
     build_flag_templates:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Pod Label Webhook Development Guide
+
+## Build & Test Commands
+- Build: `make build`
+- Test all: `make test` 
+- Run single test: `go test -v ./internal/webhook -run TestCreatePatch`
+- Integration tests: `make test-integration`
+- Fuzz tests: `make fuzz` or `go test -fuzz=FuzzCreatePatch -fuzztime=1m ./internal/webhook/`
+- Lint: `make lint`
+- Format code: `make fmt`
+- Pre-commit check: `make verify`
+
+## Code Style Guidelines
+- Use structured error types with appropriate context (see error.go)
+- Context-aware logging with zerolog (`.With()` and `.Logger()` pattern)
+- Comprehensive documentation with package/function comments
+- Import order: standard lib → third-party → internal packages
+- Table-driven tests with testify assertions
+- Use clock interface for time-based tests
+- Structured metrics recording for operations
+- Constants defined at package level with descriptive comments
+- Verbose debug logging with appropriate context fields

--- a/METRICS.md
+++ b/METRICS.md
@@ -1,23 +1,23 @@
 # Metrics
 
-The pod-label-webhook exposes Prometheus metrics on the `/metrics` endpoint. This document describes the available metrics and how to use them.
+The add-pod-label exposes Prometheus metrics on the `/metrics` endpoint. This document describes the available metrics and how to use them.
 
 ## Available Metrics
 
 ### Request Metrics
 
-| Metric Name                                  | Type      | Description                        | Labels                     |
-| -------------------------------------------- | --------- | ---------------------------------- | -------------------------- |
-| `pod_label_webhook_requests_total`           | Counter   | Total number of requests processed | `path`, `method`, `status` |
-| `pod_label_webhook_request_duration_seconds` | Histogram | Request duration in seconds        | `path`, `method`           |
-| `pod_label_webhook_errors_total`             | Counter   | Total number of errors encountered | `path`, `method`, `status` |
+| Metric Name                              | Type      | Description                        | Labels                     |
+| ---------------------------------------- | --------- | ---------------------------------- | -------------------------- |
+| `add_pod_label_requests_total`           | Counter   | Total number of requests processed | `path`, `method`, `status` |
+| `add_pod_label_request_duration_seconds` | Histogram | Request duration in seconds        | `path`, `method`           |
+| `add_pod_label_errors_total`             | Counter   | Total number of errors encountered | `path`, `method`, `status` |
 
 ### Health Metrics
 
-| Metric Name                          | Type  | Description                                             | Labels |
-| ------------------------------------ | ----- | ------------------------------------------------------- | ------ |
-| `pod_label_webhook_readiness_status` | Gauge | Current readiness status (1 for ready, 0 for not ready) | None   |
-| `pod_label_webhook_liveness_status`  | Gauge | Current liveness status (1 for alive, 0 for not alive)  | None   |
+| Metric Name                      | Type  | Description                                             | Labels |
+| -------------------------------- | ----- | ------------------------------------------------------- | ------ |
+| `add_pod_label_readiness_status` | Gauge | Current readiness status (1 for ready, 0 for not ready) | None   |
+| `add_pod_label_liveness_status`  | Gauge | Current liveness status (1 for alive, 0 for not alive)  | None   |
 
 ## Labels
 
@@ -68,10 +68,10 @@ spec:
   subject:
     organizations:
       - webhook-system
-  commonName: pod-label-webhook-metrics
+  commonName: add-pod-label-metrics
   dnsNames:
-    - pod-label-webhook.webhook-test.svc
-    - pod-label-webhook.webhook-test.svc.cluster.local
+    - add-pod-label.webhook-test.svc
+    - add-pod-label.webhook-test.svc.cluster.local
   issuerRef:
     name: webhook-selfsigned-issuer
     kind: Issuer
@@ -83,12 +83,12 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: pod-label-webhook
+  name: add-pod-label
   namespace: webhook-test
 spec:
   selector:
     matchLabels:
-      app: pod-label-webhook
+      app: add-pod-label
   namespaceSelector:
     matchNames:
       - webhook-test
@@ -118,65 +118,65 @@ spec:
 
 ```promql
 # Request rate over the last 5 minutes
-rate(pod_label_webhook_requests_total[5m])
+rate(add_pod_label_requests_total[5m])
 
 # Error rate over the last 5 minutes
-rate(pod_label_webhook_errors_total[5m])
+rate(add_pod_label_errors_total[5m])
 ```
 
 ### Latency
 
 ```promql
 # 95th percentile latency over the last hour
-histogram_quantile(0.95, sum(rate(pod_label_webhook_request_duration_seconds_bucket[1h])) by (le))
+histogram_quantile(0.95, sum(rate(add_pod_label_request_duration_seconds_bucket[1h])) by (le))
 
 # Average request duration
-rate(pod_label_webhook_request_duration_seconds_sum[5m]) /
-rate(pod_label_webhook_request_duration_seconds_count[5m])
+rate(add_pod_label_request_duration_seconds_sum[5m]) /
+rate(add_pod_label_request_duration_seconds_count[5m])
 ```
 
 ### Health Status
 
 ```promql
 # Current readiness status
-pod_label_webhook_readiness_status
+add_pod_label_readiness_status
 
 # Current liveness status
-pod_label_webhook_liveness_status
+add_pod_label_liveness_status
 ```
 
 ## Example Alerts
 
 ```yaml
 groups:
-  - name: pod-label-webhook
+  - name: add-pod-label
     rules:
       - alert: HighErrorRate
         expr: |
-          sum(rate(pod_label_webhook_errors_total[5m])) /
-          sum(rate(pod_label_webhook_requests_total[5m])) > 0.1
+          sum(rate(add_pod_label_errors_total[5m])) /
+          sum(rate(add_pod_label_requests_total[5m])) > 0.1
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: High error rate in pod-label-webhook
+          summary: High error rate in add-pod-label
           description: Error rate is above 10% for the last 5 minutes
 
       - alert: HighLatency
         expr: |
           histogram_quantile(0.95,
-            sum(rate(pod_label_webhook_request_duration_seconds_bucket[5m]))
+            sum(rate(add_pod_label_request_duration_seconds_bucket[5m]))
             by (le)
           ) > 1
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: High latency in pod-label-webhook
+          summary: High latency in add-pod-label
           description: 95th percentile latency is above 1 second for the last 5 minutes
 
       - alert: WebhookNotReady
-        expr: pod_label_webhook_readiness_status == 0
+        expr: add_pod_label_readiness_status == 0
         for: 5m
         labels:
           severity: critical
@@ -187,7 +187,7 @@ groups:
 
 ## Example Grafana Dashboard
 
-The Grafana dashboard JSON can be found in [dashboards/pod-label-webhook.json](dashboards/pod-label-webhook.json).
+The Grafana dashboard JSON can be found in [dashboards/add-pod-label.json](dashboards/add-pod-label.json).
 
 1. Request Rate gauge
 2. Request Duration (P95) time series

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ verify: lint-all test
 
 # Format Go code using goimports
 fmt:
-	goimports -local github.com/jjshanks/pod-label-webhook -w .
+	goimports -local github.com/jjshanks/add-pod-label -w .

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ spec:
 
 ## Prerequisites
 
-- Go 1.23+
+- Go 1.24+
 - Docker
 - Kind (for local development)
 - kubectl
@@ -64,8 +64,8 @@ spec:
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/jjshanks/pod-label-webhook.git
-cd pod-label-webhook
+git clone https://github.com/jjshanks/add-pod-label.git
+cd add-pod-label
 ```
 
 2. Build and run tests:
@@ -93,7 +93,7 @@ kubectl apply -f manifests/
 Pre-built images are available from GitHub Container Registry:
 
 ```bash
-ghcr.io/jjshanks/pod-label-webhook:latest
+ghcr.io/jjshanks/add-pod-label:latest
 ```
 
 ## Configuration
@@ -153,13 +153,26 @@ You can customize these settings by modifying the deployment manifest.
 ### Project Structure
 
 ```
-├── pkg/webhook/      # Core webhook implementation
-│   ├── cmd/         # Command Line Interface
-│   ├── webhook.go   # Main webhook logic
-│   └── *_test.go    # Tests
-├── tests/           # Test resources
-│   ├── manifests/   # Test deployment manifests
-│   └── scripts/     # Testing scripts
+├── cmd/             # Command line interface
+│   └── webhook/     # Main webhook command
+│       └── main.go  # Entry point
+├── internal/        # Private implementation code
+│   ├── config/      # Configuration handling
+│   └── webhook/     # Core webhook implementation
+│       ├── webhook.go   # Main webhook logic
+│       ├── server.go    # Server implementation
+│       ├── metrics.go   # Metrics collection
+│       ├── health.go    # Health checking
+│       ├── error.go     # Error types
+│       ├── clock.go     # Time utilities
+│       └── *_test.go    # Tests
+├── pkg/             # Public API packages
+│   └── k8s/         # Kubernetes utilities
+├── test/            # Test resources
+│   ├── e2e/         # End-to-end tests
+│   │   └── manifests/  # Test deployment manifests
+│   └── integration/ # Integration test scripts
+├── dashboards/      # Grafana dashboards
 └── Dockerfile       # Container build definition
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pod Label Webhook
+# Add Pod Label
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/jjshanks/add-pod-label)](https://goreportcard.com/report/github.com/jjshanks/add-pod-label)
 [![Go](https://github.com/jjshanks/add-pod-label/workflows/Go/badge.svg)](https://github.com/jjshanks/add-pod-label/actions?query=workflow%3AGo)
@@ -27,7 +27,7 @@ This webhook intercepts pod creation requests in Kubernetes and adds a "hello: w
 By default, the webhook adds a "hello: world" label to all pods. This behavior can be controlled using the following annotation:
 
 ```yaml
-pod-label-webhook.jjshanks.github.com/add-hello-world: "false"
+add-pod-label.jjshanks.github.com/add-hello-world: "false"
 ```
 
 Example deployment with labeling disabled:
@@ -41,7 +41,7 @@ spec:
   template:
     metadata:
       annotations:
-        pod-label-webhook.jjshanks.github.com/add-hello-world: "false"
+        add-pod-label.jjshanks.github.com/add-hello-world: "false"
     spec:
       containers:
         - name: nginx

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -11,8 +11,8 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/jjshanks/pod-label-webhook/internal/config"
-	"github.com/jjshanks/pod-label-webhook/internal/webhook"
+	"github.com/jjshanks/add-pod-label/internal/config"
+	"github.com/jjshanks/add-pod-label/internal/webhook"
 )
 
 // Configuration variables and root command definition

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -1,4 +1,4 @@
-// Package main implements the pod-label-webhook server, which adds labels to Kubernetes pods
+// Package main implements the add-pod-label server, which adds labels to Kubernetes pods
 // via a mutating admission webhook.
 //
 // The webhook server supports configuration through environment variables, command line flags,
@@ -78,7 +78,7 @@ func init() {
 	rootCmd.Flags().String("tracing-endpoint", "", "OpenTelemetry collector endpoint (e.g., otel-collector:4317)")
 	rootCmd.Flags().Bool("tracing-insecure", false, "Use insecure connection to the collector")
 	rootCmd.Flags().String("service-namespace", "default", "Namespace of the service for resource attribution")
-	rootCmd.Flags().String("service-name", "pod-label-webhook", "Name of the service for resource attribution")
+	rootCmd.Flags().String("service-name", "add-pod-label", "Name of the service for resource attribution")
 	rootCmd.Flags().String("service-version", "dev", "Version of the service for resource attribution")
 }
 

--- a/dashboards/add-pod-label.json
+++ b/dashboards/add-pod-label.json
@@ -61,7 +61,7 @@
               "type": "prometheus",
               "uid": "prometheus"
             },
-            "expr": "sum(rate(pod_label_webhook_requests_total[5m]))",
+            "expr": "sum(rate(add_pod_label_requests_total[5m]))",
             "refId": "A"
           }
         ],
@@ -151,7 +151,7 @@
               "type": "prometheus",
               "uid": "prometheus"
             },
-            "expr": "histogram_quantile(0.95, sum(rate(pod_label_webhook_request_duration_seconds_bucket[5m])) by (le))",
+            "expr": "histogram_quantile(0.95, sum(rate(add_pod_label_request_duration_seconds_bucket[5m])) by (le))",
             "refId": "A"
           }
         ],
@@ -227,7 +227,7 @@
               "type": "prometheus",
               "uid": "prometheus"
             },
-            "expr": "pod_label_webhook_readiness_status",
+            "expr": "add_pod_label_readiness_status",
             "refId": "A"
           }
         ],
@@ -313,7 +313,7 @@
               "type": "prometheus",
               "uid": "prometheus"
             },
-            "expr": "sum(rate(pod_label_webhook_errors_total[5m])) by (path)",
+            "expr": "sum(rate(add_pod_label_errors_total[5m])) by (path)",
             "refId": "A"
           }
         ],
@@ -336,8 +336,8 @@
       "to": "now"
     },
     "timepicker": {},
-    "title": "Pod Label Webhook",
-    "uid": "pod-label-webhook",
+    "title": "Add Pod Label",
+    "uid": "add-pod-label",
     "version": 1,
     "weekStart": ""
   }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jjshanks/pod-label-webhook
+module github.com/jjshanks/add-pod-label
 
 go 1.24.1
 

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-COPY add-pod-label /pod-label-webhook
-ENTRYPOINT ["/pod-label-webhook"]
+COPY add-pod-label /add-pod-label
+ENTRYPOINT ["/add-pod-label"]

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-COPY add-pod-label /add-pod-label
-ENTRYPOINT ["/add-pod-label"]
+COPY add-pod-label /pod-label-webhook
+ENTRYPOINT ["/pod-label-webhook"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,7 +65,7 @@ func New() *Config {
 		TracingEndpoint:     "",
 		TracingInsecure:     false,
 		ServiceNamespace:    "default",
-		ServiceName:         "pod-label-webhook",
+		ServiceName:         "add-pod-label",
 		ServiceVersion:      "dev",
 	}
 }

--- a/internal/webhook/health_test.go
+++ b/internal/webhook/health_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jjshanks/pod-label-webhook/internal/config"
+	"github.com/jjshanks/add-pod-label/internal/config"
 )
 
 func TestHealthState(t *testing.T) {

--- a/internal/webhook/metrics.go
+++ b/internal/webhook/metrics.go
@@ -16,7 +16,7 @@ import (
 const (
 	// metricsNamespace defines the base namespace for all webhook metrics
 	// This ensures unique and consistent metric naming across the application
-	metricsNamespace = "pod_label_webhook"
+	metricsNamespace = "add_pod_label"
 
 	// Label operation results
 	labelOperationSuccess = "success"

--- a/internal/webhook/metrics_test.go
+++ b/internal/webhook/metrics_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jjshanks/pod-label-webhook/internal/config"
+	"github.com/jjshanks/add-pod-label/internal/config"
 )
 
 // Helper function to safely extract float value from a metric

--- a/internal/webhook/metrics_test.go
+++ b/internal/webhook/metrics_test.go
@@ -202,7 +202,7 @@ func TestMetricsMiddlewareEdgeCases(t *testing.T) {
 
 				// Find the duration histogram metric
 				for _, mf := range metricFamilies {
-					if mf.GetName() == "pod_label_webhook_request_duration_seconds" {
+					if mf.GetName() == "add_pod_label_request_duration_seconds" {
 						foundDurationMetric = true
 						// Look through histogram buckets
 						for _, m := range mf.GetMetric() {
@@ -365,14 +365,14 @@ func TestMetricsEndpoint(t *testing.T) {
 			setupMetrics: func(m *metrics) {
 				m.requestCounter.WithLabelValues("/test", "GET", "200").Inc()
 			},
-			expectedMetric: `pod_label_webhook_requests_total{method="GET",path="/test",status="200"} 1`,
+			expectedMetric: `add_pod_label_requests_total{method="GET",path="/test",status="200"} 1`,
 		},
 		{
 			name: "health metrics",
 			setupMetrics: func(m *metrics) {
 				m.updateHealthMetrics(true, true)
 			},
-			expectedMetric: `pod_label_webhook_readiness_status 1`,
+			expectedMetric: `add_pod_label_readiness_status 1`,
 		},
 	}
 
@@ -468,7 +468,7 @@ func TestIntegrationWithServer(t *testing.T) {
 			method:     "POST",
 			body:       "{}",
 			wantStatus: http.StatusBadRequest, // Because the body isn't valid admission review
-			wantMetric: `pod_label_webhook_requests_total{method="POST",path="/mutate",status="400"} 1`,
+			wantMetric: `add_pod_label_requests_total{method="POST",path="/mutate",status="400"} 1`,
 			checkError: true,
 		},
 		{
@@ -476,7 +476,7 @@ func TestIntegrationWithServer(t *testing.T) {
 			endpoint:   "/healthz",
 			method:     "GET",
 			wantStatus: http.StatusOK,
-			wantMetric: `pod_label_webhook_requests_total{method="GET",path="/healthz",status="200"} 1`,
+			wantMetric: `add_pod_label_requests_total{method="GET",path="/healthz",status="200"} 1`,
 		},
 	}
 
@@ -520,7 +520,7 @@ func TestIntegrationWithServer(t *testing.T) {
 			assert.Contains(t, string(metricsBody), tt.wantMetric)
 
 			if tt.checkError && w.Code >= 400 {
-				assert.Contains(t, string(metricsBody), `pod_label_webhook_errors_total`)
+				assert.Contains(t, string(metricsBody), `add_pod_label_errors_total`)
 			}
 		})
 	}
@@ -542,7 +542,7 @@ func TestMetricRecording(t *testing.T) {
 		// Label operation test cases
 		{
 			name:       "successful label operation",
-			metricName: "pod_label_webhook_label_operations_total",
+			metricName: "add_pod_label_label_operations_total",
 			operation:  labelOperationSuccess,
 			namespace:  "default",
 			recorded:   true,
@@ -553,7 +553,7 @@ func TestMetricRecording(t *testing.T) {
 		},
 		{
 			name:       "skipped label operation",
-			metricName: "pod_label_webhook_label_operations_total",
+			metricName: "add_pod_label_label_operations_total",
 			operation:  labelOperationSkipped,
 			namespace:  "test-ns",
 			recorded:   true,
@@ -564,7 +564,7 @@ func TestMetricRecording(t *testing.T) {
 		},
 		{
 			name:       "error label operation",
-			metricName: "pod_label_webhook_label_operations_total",
+			metricName: "add_pod_label_label_operations_total",
 			operation:  labelOperationError,
 			namespace:  "error-ns",
 			recorded:   true,
@@ -576,7 +576,7 @@ func TestMetricRecording(t *testing.T) {
 		// Annotation validation test cases
 		{
 			name:       "valid annotation",
-			metricName: "pod_label_webhook_annotation_validation_total",
+			metricName: "add_pod_label_annotation_validation_total",
 			operation:  annotationValid,
 			namespace:  "default",
 			recorded:   true,
@@ -587,7 +587,7 @@ func TestMetricRecording(t *testing.T) {
 		},
 		{
 			name:       "invalid annotation",
-			metricName: "pod_label_webhook_annotation_validation_total",
+			metricName: "add_pod_label_annotation_validation_total",
 			operation:  annotationInvalid,
 			namespace:  "test-ns",
 			recorded:   true,
@@ -598,7 +598,7 @@ func TestMetricRecording(t *testing.T) {
 		},
 		{
 			name:       "missing annotation",
-			metricName: "pod_label_webhook_annotation_validation_total",
+			metricName: "add_pod_label_annotation_validation_total",
 			operation:  annotationMissing,
 			namespace:  "missing-ns",
 			recorded:   true,

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -62,7 +62,7 @@ func NewServer(cfg *config.Config) (*Server, error) {
 	// Create base logger with common fields
 	logger := zerolog.New(os.Stdout).With().
 		Timestamp().
-		Str("service", "pod-label-webhook").
+		Str("service", "add-pod-label").
 		Logger()
 
 	// Configure log level

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 
-	"github.com/jjshanks/pod-label-webhook/internal/config"
+	"github.com/jjshanks/add-pod-label/internal/config"
 )
 
 const (

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -345,7 +345,7 @@ func NewTestServer(cfg *config.Config, reg prometheus.Registerer) (*Server, erro
 	// Create base logger with common fields
 	logger := zerolog.New(os.Stdout).With().
 		Timestamp().
-		Str("service", "pod-label-webhook").
+		Str("service", "add-pod-label").
 		Logger()
 
 	// Configure log level

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jjshanks/pod-label-webhook/internal/config"
+	"github.com/jjshanks/add-pod-label/internal/config"
 )
 
 // portAllocator manages test port allocation to prevent conflicts

--- a/internal/webhook/tracer.go
+++ b/internal/webhook/tracer.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// tracerName is the name of the tracer used by the webhook
-	tracerName = "github.com/jjshanks/pod-label-webhook"
+	tracerName = "github.com/jjshanks/add-pod-label"
 )
 
 // tracer is responsible for managing OpenTelemetry tracing functionality.

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-const annotationKey = "pod-label-webhook.jjshanks.github.com/add-hello-world"
+const annotationKey = "add-pod-label.jjshanks.github.com/add-hello-world"
 
 var (
 	runtimeScheme = runtime.NewScheme()

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/jjshanks/pod-label-webhook/internal/config"
+	"github.com/jjshanks/add-pod-label/internal/config"
 )
 
 // TestServer is a helper struct for testing

--- a/test/e2e/manifests/deployment-trace.yaml
+++ b/test/e2e/manifests/deployment-trace.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pod-label-webhook
+  name: add-pod-label
   namespace: webhook-test
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: pod-label-webhook
+      app: add-pod-label
   template:
     metadata:
       labels:
-        app: pod-label-webhook
+        app: add-pod-label
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8443"
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/jjshanks/pod-label-webhook:latest
+          image: ghcr.io/jjshanks/add-pod-label:latest
           imagePullPolicy: IfNotPresent
           args:
             - "--cert-file=/tls/tls.crt"
@@ -41,7 +41,7 @@ spec:
             - name: WEBHOOK_SERVICE_NAMESPACE
               value: "webhook-test"
             - name: WEBHOOK_SERVICE_NAME
-              value: "pod-label-webhook"
+              value: "add-pod-label"
             - name: WEBHOOK_SERVICE_VERSION
               value: "test"
           ports:
@@ -79,13 +79,13 @@ spec:
       volumes:
         - name: cert
           secret:
-            secretName: pod-label-webhook-cert
+            secretName: add-pod-label-cert
             defaultMode: 0600
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: pod-label-webhook
+  name: add-pod-label
   namespace: webhook-test
   annotations:
     prometheus.io/scrape: "true"
@@ -101,4 +101,4 @@ spec:
       targetPort: 8443
       name: metrics
   selector:
-    app: pod-label-webhook
+    app: add-pod-label

--- a/test/e2e/manifests/deployment.yaml
+++ b/test/e2e/manifests/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/jjshanks/add-pod-label:latest
+          image: ghcr.io/jjshanks/pod-label-webhook:latest
           imagePullPolicy: IfNotPresent
           args:
             - "--cert-file=/tls/tls.crt"

--- a/test/e2e/manifests/deployment.yaml
+++ b/test/e2e/manifests/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/jjshanks/pod-label-webhook:latest
+          image: ghcr.io/jjshanks/add-pod-label:latest
           imagePullPolicy: IfNotPresent
           args:
             - "--cert-file=/tls/tls.crt"

--- a/test/e2e/manifests/deployment.yaml
+++ b/test/e2e/manifests/deployment.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pod-label-webhook
+  name: add-pod-label
   namespace: webhook-test
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: pod-label-webhook
+      app: add-pod-label
   template:
     metadata:
       labels:
-        app: pod-label-webhook
+        app: add-pod-label
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8443"
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/jjshanks/pod-label-webhook:latest
+          image: ghcr.io/jjshanks/add-pod-label:latest
           imagePullPolicy: IfNotPresent
           args:
             - "--cert-file=/tls/tls.crt"
@@ -66,13 +66,13 @@ spec:
       volumes:
         - name: cert
           secret:
-            secretName: pod-label-webhook-cert
+            secretName: add-pod-label-cert
             defaultMode: 0600
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: pod-label-webhook
+  name: add-pod-label
   namespace: webhook-test
   annotations:
     prometheus.io/scrape: "true"
@@ -88,4 +88,4 @@ spec:
       targetPort: 8443
       name: metrics
   selector:
-    app: pod-label-webhook
+    app: add-pod-label

--- a/test/e2e/manifests/test-deployment.yaml
+++ b/test/e2e/manifests/test-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: integ-test-no-label
       annotations:
-        pod-label-webhook.jjshanks.github.com/add-hello-world: "false"
+        add-pod-label.jjshanks.github.com/add-hello-world: "false"
     spec:
       containers:
         - name: integ-test-no-label

--- a/test/e2e/manifests/webhook.yaml
+++ b/test/e2e/manifests/webhook.yaml
@@ -8,21 +8,21 @@ metadata:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: pod-label-webhook-cert
+  name: add-pod-label-cert
   namespace: webhook-test
 spec:
   dnsNames:
-    - pod-label-webhook.webhook-test.svc
-    - pod-label-webhook.webhook-test.svc.cluster.local
+    - add-pod-label.webhook-test.svc
+    - add-pod-label.webhook-test.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: pod-label-selfsigned-issuer
-  secretName: pod-label-webhook-cert
+    name: add-pod-label-selfsigned-issuer
+  secretName: add-pod-label-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: pod-label-selfsigned-issuer
+  name: add-pod-label-selfsigned-issuer
   namespace: webhook-test
 spec:
   selfSigned: {}
@@ -30,14 +30,14 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: pod-label-webhook
+  name: add-pod-label
   annotations:
-    cert-manager.io/inject-ca-from: webhook-test/pod-label-webhook-cert
+    cert-manager.io/inject-ca-from: webhook-test/add-pod-label-cert
 webhooks:
-  - name: pod-label.example.com
+  - name: add-pod-label.example.com
     clientConfig:
       service:
-        name: pod-label-webhook
+        name: add-pod-label
         namespace: webhook-test
         path: "/mutate"
       caBundle: ""

--- a/test/integration/integ-test.sh
+++ b/test/integration/integ-test.sh
@@ -19,18 +19,18 @@ kubectl wait --for=condition=Available --timeout=60s -n default deployment/integ
 kubectl wait --for=condition=Available --timeout=60s -n default deployment/integ-test-no-label
 
 echo "Checking webhook pod health status..."
-WEBHOOK_POD=$(kubectl get pods -n webhook-test -l app=pod-label-webhook -o jsonpath='{.items[0].metadata.name}')
+WEBHOOK_POD=$(kubectl get pods -n webhook-test -l app=add-pod-label -o jsonpath='{.items[0].metadata.name}')
 
 # Wait for pod to be ready
 echo "Waiting for webhook pod to be ready..."
 kubectl wait --for=condition=Ready --timeout=60s -n webhook-test pod/$WEBHOOK_POD
 
 # Get the service port
-WEBHOOK_PORT=$(kubectl get service pod-label-webhook -n webhook-test -o jsonpath='{.spec.ports[0].port}')
+WEBHOOK_PORT=$(kubectl get service add-pod-label -n webhook-test -o jsonpath='{.spec.ports[0].port}')
 
 # Setup port forwarding
 echo "Setting up port forwarding..."
-kubectl port-forward -n webhook-test service/pod-label-webhook $LOCAL_PORT:$WEBHOOK_PORT &
+kubectl port-forward -n webhook-test service/add-pod-label $LOCAL_PORT:$WEBHOOK_PORT &
 PORT_FORWARD_PID=$!
 
 # Wait for port forwarding to be established
@@ -69,21 +69,21 @@ echo "Verifying metrics..."
 sleep 5
 
 # Check readiness status first
-if ! check_metric "pod_label_webhook_readiness_status" "" "1" "Webhook readiness" "$LOCAL_PORT"; then
+if ! check_metric "add_pod_label_readiness_status" "" "1" "Webhook readiness" "$LOCAL_PORT"; then
     exit 1
 fi
 
 # Check request metrics
-if ! check_metric "pod_label_webhook_requests_total" 'method="POST",path="/mutate",status="200"' "1" "Successful mutate requests" "$LOCAL_PORT"; then
+if ! check_metric "add_pod_label_requests_total" 'method="POST",path="/mutate",status="200"' "1" "Successful mutate requests" "$LOCAL_PORT"; then
     exit 1
 fi
 
 # Check label operations
-if ! check_metric "pod_label_webhook_label_operations_total" 'namespace="default",operation="success"' "1" "Successful label operations" "$LOCAL_PORT"; then
+if ! check_metric "add_pod_label_label_operations_total" 'namespace="default",operation="success"' "1" "Successful label operations" "$LOCAL_PORT"; then
     exit 1
 fi
 
-if ! check_metric "pod_label_webhook_label_operations_total" 'namespace="default",operation="skipped"' "1" "Skipped label operations" "$LOCAL_PORT"; then
+if ! check_metric "add_pod_label_label_operations_total" 'namespace="default",operation="skipped"' "1" "Skipped label operations" "$LOCAL_PORT"; then
     exit 1
 fi
 

--- a/test/integration/kind-deploy-trace.sh
+++ b/test/integration/kind-deploy-trace.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Set default cluster name if not provided
 CLUSTER_NAME=${KIND_CLUSTER_NAME:-webhook-test}
 NAMESPACE=${NAMESPACE:-webhook-test}
-IMAGE_NAME=${IMAGE_NAME:-ghcr.io/jjshanks/pod-label-webhook}
+IMAGE_NAME=${IMAGE_NAME:-ghcr.io/jjshanks/add-pod-label}
 VERSION=${VERSION:-latest}
 
 kind export kubeconfig --name ${CLUSTER_NAME}
@@ -13,7 +13,7 @@ kind load docker-image ${IMAGE_NAME}:${VERSION} --name ${CLUSTER_NAME}
 
 # Apply webhook configuration
 kubectl apply -f test/e2e/manifests/webhook.yaml
-kubectl wait --for=condition=Ready --timeout=60s -n ${NAMESPACE} certificate/pod-label-webhook-cert
+kubectl wait --for=condition=Ready --timeout=60s -n ${NAMESPACE} certificate/add-pod-label-cert
 
 # Apply OpenTelemetry collector and test services
 kubectl apply -f test/e2e/manifests/test-deployment-trace.yaml
@@ -23,4 +23,4 @@ kubectl wait --for=condition=Available --timeout=60s -n webhook-test deployment/
 
 # Apply deployment with tracing enabled
 kubectl apply -f test/e2e/manifests/deployment-trace.yaml
-kubectl wait --for=condition=Available --timeout=60s -n ${NAMESPACE} deployment/pod-label-webhook
+kubectl wait --for=condition=Available --timeout=60s -n ${NAMESPACE} deployment/add-pod-label

--- a/test/integration/kind-deploy.sh
+++ b/test/integration/kind-deploy.sh
@@ -5,13 +5,13 @@ set -euo pipefail
 # Set default cluster name if not provided
 CLUSTER_NAME=${KIND_CLUSTER_NAME:-webhook-test}
 NAMESPACE=${NAMESPACE:-webhook-test}
-IMAGE_NAME=${IMAGE_NAME:-ghcr.io/jjshanks/pod-label-webhook}
+IMAGE_NAME=${IMAGE_NAME:-ghcr.io/jjshanks/add-pod-label}
 VERSION=${VERSION:-latest}
 
 kind export kubeconfig --name ${CLUSTER_NAME}
 kind load docker-image ${IMAGE_NAME}:${VERSION} --name ${CLUSTER_NAME}
 
 kubectl apply -f test/e2e/manifests/webhook.yaml
-kubectl wait --for=condition=Ready --timeout=60s -n ${NAMESPACE} certificate/pod-label-webhook-cert
+kubectl wait --for=condition=Ready --timeout=60s -n ${NAMESPACE} certificate/add-pod-label-cert
 kubectl apply -f test/e2e/manifests/deployment.yaml
-kubectl wait --for=condition=Available --timeout=60s -n ${NAMESPACE} deployment/pod-label-webhook
+kubectl wait --for=condition=Available --timeout=60s -n ${NAMESPACE} deployment/add-pod-label


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)

run-integ-test

## Summary by Sourcery

Rename project from pod-label-webhook to add-pod-label and restructure project layout

Enhancements:
- Restructure project directory layout to improve code organization
- Separate internal and public packages more clearly

Build:
- Update Go version requirement from 1.23+ to 1.24+

Documentation:
- Add CLAUDE.md with development guide and common commands
- Update README.md with new project name and cloning instructions

Chores:
- Rename GitHub repository and module name from pod-label-webhook to add-pod-label
- Update all import paths and references to reflect the new project name